### PR TITLE
READMEにTerraform準備セクションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,94 @@ aws sts get-caller-identity --profile terraform-master
 ```
 
 `Arn` に `AWSReservedSSO` が含まれていれば、IAM Identity Center経由で正常にアクセスできています。
+
+## Terraform準備
+
+### 状態管理用S3バケット作成
+
+1. AWSコンソールでS3バケットを作成します
+   - バケット名: `terraform-state-{UUID}` など、グローバルでユニークな名前を指定
+   - リージョン: `ap-northeast-1` (東京)
+   - バージョニング: 有効化を推奨
+
+2. 作成したバケット名を `backend.tf` の `bucket` 項目に反映します
+
+### Terraform初期化
+
+作業ディレクトリでTerraformを初期化します。
+
+```bash
+terraform init
+```
+
+### AWS Organizationsリソースのインポート
+
+以下の手順で、既存のAWS Organizationsリソースをterraform importコマンドを使用してTerraformの管理下に取り込みます。
+
+#### 1. IAM Identity Centerインスタンスのインポート
+
+```bash
+# IAM Identity CenterインスタンスARNを取得
+aws sso-admin list-instances --profile terraform-master
+
+# インスタンスARNを使用してインポート
+terraform import aws_ssoadmin_instances.main <instance-arn>
+```
+
+#### 2. グループのインポート
+
+```bash
+# グループIDを取得
+aws identitystore list-groups --identity-store-id <identity-store-id> --profile terraform-master
+
+# グループをインポート
+terraform import aws_identitystore_group.terraform_administrators <identity-store-id>/<group-id>
+```
+
+#### 3. ユーザーのインポート
+
+```bash
+# ユーザーIDを取得
+aws identitystore list-users --identity-store-id <identity-store-id> --profile terraform-master
+
+# ユーザーをインポート
+terraform import aws_identitystore_user.example_user <identity-store-id>/<user-id>
+```
+
+#### 4. アクセス許可セットのインポート
+
+```bash
+# アクセス許可セットARNを取得
+aws sso-admin list-permission-sets --instance-arn <instance-arn> --profile terraform-master
+
+# アクセス許可セットをインポート
+terraform import aws_ssoadmin_permission_set.admin_access <permission-set-arn>,<instance-arn>
+```
+
+#### 5. グループへのユーザー割り当てのインポート
+
+```bash
+# グループメンバーシップをインポート
+terraform import aws_identitystore_group_membership.example <identity-store-id>/<membership-id>
+```
+
+#### 6. アカウントへのアクセス許可割り当てのインポート
+
+```bash
+# アクセス許可の割り当てをインポート
+terraform import aws_ssoadmin_account_assignment.example <permission-set-arn>,<instance-arn>,<account-id>,GROUP,<group-id>
+```
+
+### インポート後の確認
+
+インポートが完了したら、以下のコマンドで状態を確認します。
+
+```bash
+# Terraformの状態を確認
+terraform state list
+
+# 差分がないことを確認
+terraform plan
+```
+
+`terraform plan` の結果で変更が検出されない場合、インポートは正常に完了しています。


### PR DESCRIPTION
## 変更内容

README.mdに「Terraform準備」セクションを追加し、AWS Organizationsのリソース(グループ、ユーザー、アクセス許可セット等)をTerraformで管理するためのインポート手順を記載しました。

### 追加した内容
- Terraform初期化の手順
- IAM Identity Centerインスタンスのインポート方法
- グループのインポート方法
- ユーザーのインポート方法
- アクセス許可セットのインポート方法
- グループメンバーシップのインポート方法
- アカウントへのアクセス許可割り当てのインポート方法
- インポート後の確認方法

Close #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 別途人力対応
- 「状態管理用S3バケット作成」項目を追記しました。