### PR TITLE
TerraformバックエンドにS3を設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Lock files
+.terraform.lock.hcl

--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "terraform-state-919172dc-8283-4326-83de-fdfadef3bb78"
+    key            = "terraform.tfstate"
+    region         = "ap-northeast-1"
+    use_lockfile   = true
+    encrypt        = true
+  }
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = "ap-northeast-1"
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "1.14.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.26.0"
+    }
+  }
+}


### PR DESCRIPTION
## 変更内容

TerraformのバックエンドとしてS3を使用するように設定しました。

### 追加したファイル

1. **backend.tf**
   - S3バックエンドの設定
   - バケット名: `terraform-state-master-account`
   - ステートファイルの暗号化を有効化
   - DynamoDB テーブルによる状態ロック機能を追加

2. **versions.tf**
   - Terraform バージョン要件: >= 1.0
   - AWS プロバイダ バージョン: ~> 5.0
   - デフォルトタグの設定

3. **.gitignore**
   - Terraformの作業ファイルをバージョン管理から除外
   - 機密情報を含む可能性のある .tfvars ファイルを除外

### 使用前の準備

このバックエンド設定を使用する前に、以下のAWSリソースを事前に作成する必要があります:

1. S3バケット: `terraform-state-master-account`
2. DynamoDB テーブル: `terraform-state-lock` (プライマリキー: `LockID`)

Close #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 別途人力対応
- versions.tfとprovider.tfを分けました。
- versions.tfに書かれているバージョンを固定しました。
- S3バックエンドのバケット名をグローバルユニークにしました。
- DynamoDB テーブルによる状態ロック機能はdeprecatedだったので修正しました。