### PR TITLE
README構成とプロバイダ設定を調整

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,6 @@ AWS OrganizationsとIAM Identity Centerを使用して、複数のAWSアカウ�
 
 - [AWS OrganizationsとIAM Identity Centerの詳細解説](docs/aws-organizations-iam-identity-center.md)
 
-## ローカル準備
-
-Terraformを実行するために、ローカル環境に必要なツールをインストールします。
-
-### AWS CLIのインストール
-
-AWS CLIをインストールしてください。
-
-- [AWS CLI インストールガイド](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
-
-### Terraformのインストール
-
-Terraformをインストールしてください。
-
-- [Terraform インストールガイド](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
-
 ## AWS準備
 
 AWSコンソールで以下の設定を行います。
@@ -73,13 +57,27 @@ AWSコンソールで以下の設定を行います。
 9. アクセス許可セット（`AdministratorAccess`）を選択
 10. 「送信」をクリックして割り当てを完了
 
-## 疎通
+## ローカル準備
 
-IAM Identity Centerを使用してAWSにアクセスできるように設定します。
+Terraformを実行するために、ローカル環境に必要なツールをインストールし、AWS接続を設定します。
+
+### AWS CLIのインストール
+
+AWS CLIをインストールしてください。
+
+- [AWS CLI インストールガイド](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+
+### Terraformのインストール
+
+Terraformをインストールしてください。
+
+- [Terraform インストールガイド](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
 
 ### SSOログインのための設定ファイル編集
 
 `~/.aws/config` ファイルを編集して、SSO設定を追加します。
+
+※プロファイル名 `terraform-master` は [provider.tf](provider.tf:3) で指定されているため、変更しないでください。
 
 ```ini
 [profile terraform-master]

--- a/provider.tf
+++ b/provider.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  region = "ap-northeast-1"
+  region  = "ap-northeast-1"
+  profile = "terraform-master"
 
   default_tags {
     tags = {


### PR DESCRIPTION
## 変更内容

README構成の最適化とプロバイダ設定の改善を行いました。

### README構成の変更

1. **セクション順序の最適化**
   - 「AWS準備」を「AWS OrganizationsとIAM Identity Centerについて」の直後に配置
   - AWSでの準備作業を先に完了してから、ローカル環境の設定に進む流れに変更

2. **セクションのマージ**
   - 「ローカル準備」と「疎通」を「ローカル準備」セクションに統合
   - ツールのインストール、AWS接続設定、疎通確認までを一連の流れとして整理
   - 読みやすさと実際の作業手順の流れが改善されました

### プロバイダ設定の変更

- `provider.tf` にAWSプロファイル `terraform-master` を指定
- IAM Identity CenterのSSOプロファイルを使用してTerraformを実行できるように設定

Close #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 別途人力対応
- .aws/configでプロファイル名 `terraform-master`を変更してはいけない旨を追記。