### PR TITLE
Terraform AWS providerのprofile指定を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ Terraformをインストールしてください。
 
 `~/.aws/config` ファイルを編集して、SSO設定を追加します。
 
-※プロファイル名 `terraform-master` は [provider.tf](provider.tf:3) で指定されているため、変更しないでください。
-
 ```ini
 [profile terraform-master]
 sso_session = my-sso
@@ -93,8 +91,8 @@ aws sts get-caller-identity --profile terraform-master
 
 ### Terraform初期化
 
-作業ディレクトリでTerraformを初期化します。
+作業ディレクトリでTerraformを初期化します。環境変数 `AWS_PROFILE` でプロファイル名を指定してください。
 
 ```bash
-terraform init
+AWS_PROFILE=terraform-master; terraform init
 ```

--- a/provider.tf
+++ b/provider.tf
@@ -1,6 +1,5 @@
 provider "aws" {
-  region  = "ap-northeast-1"
-  profile = "terraform-master"
+  region = "ap-northeast-1"
 
   default_tags {
     tags = {


### PR DESCRIPTION
## 変更内容

Issue #18の対応として、Terraform AWS providerのprofile指定を削除し、環境変数を使用する方式に変更しました。

- [provider.tf](provider.tf) からprofile指定を削除
- [README.md](README.md) からprofile名に関する注意書きを削除
- [README.md](README.md) でterraform init実行時に環境変数 `AWS_PROFILE` を指定するように変更

これにより、プロファイル名がハードコードされず、より柔軟な設定が可能になります。

Close #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 別途人力対応
- 下記コマンドにセミコロンが足りなかったので追加
```
AWS_PROFILE=terraform-master terraform init
```
↓
```
AWS_PROFILE=terraform-master; terraform init
```