### PR TITLE
AWS OrganizationsとIAM Identity Centerの有効化

### DIFF
--- a/organizations.tf
+++ b/organizations.tf
@@ -1,0 +1,12 @@
+# AWS Organizations
+resource "aws_organizations_organization" "main" {
+  aws_service_access_principals = [
+    "sso.amazonaws.com",
+  ]
+
+  enabled_policy_types = [
+    "SERVICE_CONTROL_POLICY",
+  ]
+
+  feature_set = "ALL"
+}

--- a/sso.tf
+++ b/sso.tf
@@ -1,0 +1,14 @@
+# IAM Identity Center (AWS SSO)
+# IAM Identity Centerは既にOrganizationsと統合されているため、データソースで参照
+data "aws_ssoadmin_instances" "main" {}
+
+# Identity Centerインスタンスの情報を出力
+output "identity_center_instance_arn" {
+  description = "IAM Identity Center instance ARN"
+  value       = try(tolist(data.aws_ssoadmin_instances.main.arns)[0], null)
+}
+
+output "identity_center_identity_store_id" {
+  description = "IAM Identity Center identity store ID"
+  value       = try(tolist(data.aws_ssoadmin_instances.main.identity_store_ids)[0], null)
+}


### PR DESCRIPTION
## 概要

AWS OrganizationsとIAM Identity Centerを有効化するTerraform設定を追加しました。

## 変更内容

- **organizations.tf**: AWS Organizationsリソースを作成し、IAM Identity Center統合を有効化
- **sso.tf**: IAM Identity Centerインスタンス情報をデータソースで参照し、ARNとIdentity Store IDを出力

## 実装の詳細

### AWS Organizations
- `feature_set = "ALL"` で全機能を有効化
- IAM Identity Center (sso.amazonaws.com) へのサービスアクセスを許可
- SERVICE_CONTROL_POLICYを有効化

### IAM Identity Center
- データソースを使用してIdentity Centerインスタンス情報を取得
- インスタンスARNとIdentity Store IDを出力として提供

## 検証

`terraform plan` を実行し、構文エラーがないことを確認済みです。

Close #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)