### PR TITLE
adminグループとpioneerユーザを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,48 @@ TerraformでAWSリソースを管理するためには、AWSへのログイン�
 
 ## 使い方
 
+### 重要: Identity Centerの手動有効化について
+
+IAM Identity Center (旧AWS SSO) の有効化はTerraformでは実行できないため、AWSコンソールから手動で有効化する必要があります。
+
+#### 実行手順
+
+1. **organizations.tfの実行**
+   ```bash
+   AWS_PROFILE=terraform-master; terraform init
+   AWS_PROFILE=terraform-master; terraform apply -target=aws_organizations_organization.main
+   ```
+
+2. **Identity Centerの手動有効化**
+   - AWSコンソールにログイン
+   - IAM Identity Centerサービスに移動
+   - 「有効化」ボタンをクリックしてIdentity Centerを有効化
+   - 有効化が完了するまで数分待機
+
+3. **terraform.tfvarsの準備**
+   - サンプルファイルをコピーして設定ファイルを作成:
+     ```bash
+     cp terraform.tfvars.example terraform.tfvars
+     ```
+   - `terraform.tfvars`を編集してpioneerユーザーのメールアドレスを設定:
+     ```hcl
+     pioneer_email = "your-email@yourdomain.com"
+     ```
+   - このファイルは`.gitignore`に含まれているため、git管理外となります
+
+4. **残りのTerraform リソースの適用**
+   ```bash
+   AWS_PROFILE=terraform-master; terraform apply
+   ```
+
+5. **ユーザーのメールアドレス検証**
+   - Terraformでユーザーを作成した後、そのユーザーでログインするにはメールアドレスの検証が必要です
+   - AWSコンソールでIAM Identity Centerに移動
+   - 「ユーザー」メニューからpioneerユーザーを選択
+   - 「メールアドレスの検証を送信」をクリック
+   - ユーザーが受信したメールから検証リンクをクリックして検証を完了
+   - 検証完了後、パスワード設定の案内メールが送信されます
+
 ### Terraform初期化
 
 作業ディレクトリでTerraformを初期化します。環境変数 `AWS_PROFILE` でプロファイル名を指定してください。

--- a/sso.tf
+++ b/sso.tf
@@ -2,6 +2,63 @@
 # IAM Identity Centerは既にOrganizationsと統合されているため、データソースで参照
 data "aws_ssoadmin_instances" "main" {}
 
+# adminグループの作成
+resource "aws_identitystore_group" "admin" {
+  identity_store_id = tolist(data.aws_ssoadmin_instances.main.identity_store_ids)[0]
+  display_name      = "admin"
+  description       = "Administrator group - Full permissions granted"
+}
+
+# pioneerユーザの作成
+resource "aws_identitystore_user" "pioneer" {
+  identity_store_id = tolist(data.aws_ssoadmin_instances.main.identity_store_ids)[0]
+  user_name         = "pioneer"
+  display_name      = "Pioneer User"
+
+  name {
+    given_name  = "Pioneer"
+    family_name = "User"
+  }
+
+  emails {
+    value   = var.pioneer_email
+    type    = "work"
+    primary = true
+  }
+}
+
+# pioneerユーザをadminグループに追加
+resource "aws_identitystore_group_membership" "pioneer_admin" {
+  identity_store_id = tolist(data.aws_ssoadmin_instances.main.identity_store_ids)[0]
+  group_id          = aws_identitystore_group.admin.group_id
+  member_id         = aws_identitystore_user.pioneer.user_id
+}
+
+# AdministratorAccessの許可セット作成
+resource "aws_ssoadmin_permission_set" "administrator_access" {
+  instance_arn     = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  name             = "AdministratorAccess"
+  description      = "Administrator access - Full access to all AWS services"
+  session_duration = "PT12H"
+}
+
+# AdministratorAccessポリシーをアタッチ
+resource "aws_ssoadmin_managed_policy_attachment" "administrator_access" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+# adminグループにAdministratorAccessを割り当て(Organization全体)
+resource "aws_ssoadmin_account_assignment" "admin_assignment" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn
+  principal_id       = aws_identitystore_group.admin.group_id
+  principal_type     = "GROUP"
+  target_id          = aws_organizations_organization.main.master_account_id
+  target_type        = "AWS_ACCOUNT"
+}
+
 # Identity Centerインスタンスの情報を出力
 output "identity_center_instance_arn" {
   description = "IAM Identity Center instance ARN"
@@ -11,4 +68,14 @@ output "identity_center_instance_arn" {
 output "identity_center_identity_store_id" {
   description = "IAM Identity Center identity store ID"
   value       = try(tolist(data.aws_ssoadmin_instances.main.identity_store_ids)[0], null)
+}
+
+output "admin_group_id" {
+  description = "Admin group ID"
+  value       = aws_identitystore_group.admin.group_id
+}
+
+output "pioneer_user_id" {
+  description = "Pioneer user ID"
+  value       = aws_identitystore_user.pioneer.user_id
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,3 @@
+# Pioneer user email address
+# Copy this file to terraform.tfvars and update the email address
+pioneer_email = "pioneer@example.com"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,5 @@
+variable "pioneer_email" {
+  description = "Email address for the pioneer user"
+  type        = string
+  default     = "pioneer@example.com"
+}


### PR DESCRIPTION
## 概要

Issue #24に基づき、IAM Identity Centerにadminグループとpioneerユーザを追加しました。

## 変更内容

- **adminグループの作成**: 管理者権限を持つグループをIdentity Centerに作成
- **pioneerユーザの作成**: 初期管理者ユーザとしてpioneerユーザを作成
- **権限付与**: adminグループにAdministratorAccess権限を付与し、全AWSサービスへのフルアクセスを許可
- **グループメンバーシップ**: pioneerユーザをadminグループに追加
- **README更新**: Identity Centerの手動有効化手順とTerraform実行順序を明記

## Identity Center手動有効化について

IAM Identity Centerの有効化はTerraformで実行できないため、以下の手順で作業する必要があります:

1. `organizations.tf`を先に実行
2. AWSコンソールでIdentity Centerを手動有効化
3. 残りのTerraformリソースを適用

詳細はREADME.mdに記載しています。

Close #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 別途人力対応
- terraformのdescriptionを英語に変更
- pioneerユーザのメアドをgit管理外ファイル化
- terraform.tfvarsの用意についてREADME.mdに追記