### PR TITLE
prod, stgアカウントの作成

### DIFF
--- a/organizations.tf
+++ b/organizations.tf
@@ -10,3 +10,19 @@ resource "aws_organizations_organization" "main" {
 
   feature_set = "ALL"
 }
+
+# Production Account
+resource "aws_organizations_account" "prod" {
+  name  = "prod"
+  email = var.prod_account_email
+
+  depends_on = [aws_organizations_organization.main]
+}
+
+# Staging Account
+resource "aws_organizations_account" "stg" {
+  name  = "stg"
+  email = var.stg_account_email
+
+  depends_on = [aws_organizations_organization.main]
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,3 +1,9 @@
 # Pioneer user email address
 # Copy this file to terraform.tfvars and update the email address
 pioneer_email = "pioneer@example.com"
+
+# Production account email address
+prod_account_email = "prod@example.com"
+
+# Staging account email address
+stg_account_email = "stg@example.com"

--- a/variables.tf
+++ b/variables.tf
@@ -3,3 +3,15 @@ variable "pioneer_email" {
   type        = string
   default     = "pioneer@example.com"
 }
+
+variable "prod_account_email" {
+  description = "Email address for the production account"
+  type        = string
+  default     = "prod@example.com"
+}
+
+variable "stg_account_email" {
+  description = "Email address for the staging account"
+  type        = string
+  default     = "stg@example.com"
+}


### PR DESCRIPTION
## 変更内容

AWS Organizationsでprodとstgアカウントを作成できるようにTerraformコードを追加しました。

### 実装内容
- **variables.tf**: `prod_account_email`と`stg_account_email`変数を追加
- **terraform.tfvars.example**: 新しい変数のサンプル値を追加
- **organizations.tf**: prodとstgアカウントを作成する`aws_organizations_account`リソースを追加

### 使用方法
1. `terraform.tfvars`ファイルに以下の変数を設定:
   ```hcl
   prod_account_email = "your-prod@example.com"
   stg_account_email = "your-stg@example.com"
   ```
2. `terraform apply`を実行してアカウントを作成

## テスト手順
- [ ] terraform.tfvars.exampleの記述内容を確認
- [ ] variables.tfの変数定義を確認
- [ ] organizations.tfのリソース定義を確認
- [ ] terraform planが成功することを確認（実際のapplyは環境に応じて）

Close #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)