### PR TITLE
prod, stgアカウントをstatic-prod, static-stgアカウントに変更

### DIFF
--- a/organizations.tf
+++ b/organizations.tf
@@ -11,18 +11,18 @@ resource "aws_organizations_organization" "main" {
   feature_set = "ALL"
 }
 
-# Production Account
-resource "aws_organizations_account" "prod" {
-  name  = "prod"
-  email = var.prod_account_email
+# Static Production Account
+resource "aws_organizations_account" "static_prod" {
+  name  = "static-prod"
+  email = var.static_prod_account_email
 
   depends_on = [aws_organizations_organization.main]
 }
 
-# Staging Account
-resource "aws_organizations_account" "stg" {
-  name  = "stg"
-  email = var.stg_account_email
+# Static Staging Account
+resource "aws_organizations_account" "static_stg" {
+  name  = "static-stg"
+  email = var.static_stg_account_email
 
   depends_on = [aws_organizations_organization.main]
 }

--- a/sso.tf
+++ b/sso.tf
@@ -59,23 +59,23 @@ resource "aws_ssoadmin_account_assignment" "admin_assignment_master" {
   target_type        = "AWS_ACCOUNT"
 }
 
-# adminグループにAdministratorAccessを割り当て(prodアカウント)
-resource "aws_ssoadmin_account_assignment" "admin_assignment_prod" {
+# adminグループにAdministratorAccessを割り当て(static-prodアカウント)
+resource "aws_ssoadmin_account_assignment" "admin_assignment_static_prod" {
   instance_arn       = tolist(data.aws_ssoadmin_instances.main.arns)[0]
   permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn
   principal_id       = aws_identitystore_group.admin.group_id
   principal_type     = "GROUP"
-  target_id          = aws_organizations_account.prod.id
+  target_id          = aws_organizations_account.static_prod.id
   target_type        = "AWS_ACCOUNT"
 }
 
-# adminグループにAdministratorAccessを割り当て(stgアカウント)
-resource "aws_ssoadmin_account_assignment" "admin_assignment_stg" {
+# adminグループにAdministratorAccessを割り当て(static-stgアカウント)
+resource "aws_ssoadmin_account_assignment" "admin_assignment_static_stg" {
   instance_arn       = tolist(data.aws_ssoadmin_instances.main.arns)[0]
   permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn
   principal_id       = aws_identitystore_group.admin.group_id
   principal_type     = "GROUP"
-  target_id          = aws_organizations_account.stg.id
+  target_id          = aws_organizations_account.static_stg.id
   target_type        = "AWS_ACCOUNT"
 }
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -2,8 +2,8 @@
 # Copy this file to terraform.tfvars and update the email address
 pioneer_email = "pioneer@example.com"
 
-# Production account email address
-prod_account_email = "prod@example.com"
+# Static Production account email address
+static_prod_account_email = "static-prod@example.com"
 
-# Staging account email address
-stg_account_email = "stg@example.com"
+# Static Staging account email address
+static_stg_account_email = "static-stg@example.com"

--- a/variables.tf
+++ b/variables.tf
@@ -4,14 +4,14 @@ variable "pioneer_email" {
   default     = "pioneer@example.com"
 }
 
-variable "prod_account_email" {
-  description = "Email address for the production account"
+variable "static_prod_account_email" {
+  description = "Email address for the static production account"
   type        = string
-  default     = "prod@example.com"
+  default     = "static-prod@example.com"
 }
 
-variable "stg_account_email" {
-  description = "Email address for the staging account"
+variable "static_stg_account_email" {
+  description = "Email address for the static staging account"
   type        = string
-  default     = "stg@example.com"
+  default     = "static-stg@example.com"
 }


### PR DESCRIPTION
## 概要

prod, stgアカウントを削除し、static-prod, static-stgアカウントを新しく作成しました。

## 変更内容

- **アカウント設定の変更** ([organizations.tf](organizations.tf))
  - `aws_organizations_account.prod` → `aws_organizations_account.static_prod`
  - `aws_organizations_account.stg` → `aws_organizations_account.static_stg`
  - アカウント名: `prod` → `static-prod`, `stg` → `static-stg`

- **変数名の変更** ([variables.tf](variables.tf))
  - `prod_account_email` → `static_prod_account_email`
  - `stg_account_email` → `static_stg_account_email`
  - デフォルト値も更新

- **SSO許可セット割り当ての変更** ([sso.tf](sso.tf))
  - `admin_assignment_prod` → `admin_assignment_static_prod`
  - `admin_assignment_stg` → `admin_assignment_static_stg`
  - adminグループへのAdministratorAccess割り当ては既存と同じ設定を維持

- **サンプル設定ファイルの更新** ([terraform.tfvars.example](terraform.tfvars.example))
  - 変数名とデフォルト値を更新

## 注意事項

この変更により、既存のprod, stgアカウントは削除され、新しくstatic-prod, static-stgアカウントが作成されます。

Close #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)