### PR TITLE
mainアカウントからstatic-prod, static-stgへのスイッチロール設定を追加

### DIFF
--- a/iam_roles.tf
+++ b/iam_roles.tf
@@ -1,0 +1,70 @@
+# IAM Role for Switch Role from Main Account to Static-Prod Account
+resource "aws_iam_role" "switch_role_static_prod" {
+  provider = aws.static_prod
+  name     = "SwitchRoleFromMain"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${aws_organizations_organization.main.master_account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name = "SwitchRoleFromMain"
+  }
+}
+
+# Attach AdministratorAccess policy to static-prod switch role
+resource "aws_iam_role_policy_attachment" "switch_role_static_prod_admin" {
+  provider   = aws.static_prod
+  role       = aws_iam_role.switch_role_static_prod.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+# IAM Role for Switch Role from Main Account to Static-Stg Account
+resource "aws_iam_role" "switch_role_static_stg" {
+  provider = aws.static_stg
+  name     = "SwitchRoleFromMain"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${aws_organizations_organization.main.master_account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name = "SwitchRoleFromMain"
+  }
+}
+
+# Attach AdministratorAccess policy to static-stg switch role
+resource "aws_iam_role_policy_attachment" "switch_role_static_stg_admin" {
+  provider   = aws.static_stg
+  role       = aws_iam_role.switch_role_static_stg.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+# Output the role ARNs for easy reference
+output "switch_role_static_prod_arn" {
+  description = "ARN of the switch role for static-prod account"
+  value       = aws_iam_role.switch_role_static_prod.arn
+}
+
+output "switch_role_static_stg_arn" {
+  description = "ARN of the switch role for static-stg account"
+  value       = aws_iam_role.switch_role_static_stg.arn
+}

--- a/provider.tf
+++ b/provider.tf
@@ -7,3 +7,35 @@ provider "aws" {
     }
   }
 }
+
+# Provider for static-prod account
+provider "aws" {
+  alias  = "static_prod"
+  region = "ap-northeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.static_prod.id}:role/OrganizationAccountAccessRole"
+  }
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+    }
+  }
+}
+
+# Provider for static-stg account
+provider "aws" {
+  alias  = "static_stg"
+  region = "ap-northeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.static_stg.id}:role/OrganizationAccountAccessRole"
+  }
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+    }
+  }
+}


### PR DESCRIPTION
## 概要

mainアカウントからstatic-prod, static-stgアカウントそれぞれにスイッチロールできるように設定を追加しました。

## 変更内容

### 新規ファイル

- **iam_roles.tf** (新規作成)
  - `SwitchRoleFromMain` ロールをstatic-prodアカウントに作成
  - `SwitchRoleFromMain` ロールをstatic-stgアカウントに作成
  - 両ロールにAdministratorAccessポリシーをアタッチ
  - mainアカウントのrootプリンシパルからの引き受けを許可
  - 各ロールのARNを出力として定義

### 既存ファイルの変更

- **provider.tf**
  - static-prodアカウント用のプロバイダーを追加
  - static-stgアカウント用のプロバイダーを追加
  - OrganizationAccountAccessRoleを使用してTerraformがアカウント間でリソース管理できるように設定

## 使用方法

この設定により、mainアカウントのIAMユーザーまたはロールは、以下のARNを使用してstatic-prod、static-stgアカウントにスイッチロールできます：

- static-prod: `arn:aws:iam::<static-prod-account-id>:role/SwitchRoleFromMain`
- static-stg: `arn:aws:iam::<static-stg-account-id>:role/SwitchRoleFromMain`

## 注意事項

- スイッチロールには、mainアカウントで適切な権限を持つIAMユーザーまたはロールが必要です
- 各アカウントでAdministratorAccessポリシーが付与されるため、使用には十分注意してください

Close #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)