### PR TITLE
kidsword用prod/stgアカウントを追加

### DIFF
--- a/organizations.tf
+++ b/organizations.tf
@@ -26,3 +26,19 @@ resource "aws_organizations_account" "static_stg" {
 
   depends_on = [aws_organizations_organization.main]
 }
+
+# Kidsword Production Account
+resource "aws_organizations_account" "kidsword_prod" {
+  name  = "kidsword-prod"
+  email = var.kidsword_prod_account_email
+
+  depends_on = [aws_organizations_organization.main]
+}
+
+# Kidsword Staging Account
+resource "aws_organizations_account" "kidsword_stg" {
+  name  = "kidsword-stg"
+  email = var.kidsword_stg_account_email
+
+  depends_on = [aws_organizations_organization.main]
+}

--- a/sso.tf
+++ b/sso.tf
@@ -79,6 +79,26 @@ resource "aws_ssoadmin_account_assignment" "admin_assignment_static_stg" {
   target_type        = "AWS_ACCOUNT"
 }
 
+# adminグループにAdministratorAccessを割り当て(kidsword-prodアカウント)
+resource "aws_ssoadmin_account_assignment" "admin_assignment_kidsword_prod" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn
+  principal_id       = aws_identitystore_group.admin.group_id
+  principal_type     = "GROUP"
+  target_id          = aws_organizations_account.kidsword_prod.id
+  target_type        = "AWS_ACCOUNT"
+}
+
+# adminグループにAdministratorAccessを割り当て(kidsword-stgアカウント)
+resource "aws_ssoadmin_account_assignment" "admin_assignment_kidsword_stg" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn
+  principal_id       = aws_identitystore_group.admin.group_id
+  principal_type     = "GROUP"
+  target_id          = aws_organizations_account.kidsword_stg.id
+  target_type        = "AWS_ACCOUNT"
+}
+
 # Identity Centerインスタンスの情報を出力
 output "identity_center_instance_arn" {
   description = "IAM Identity Center instance ARN"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -7,3 +7,9 @@ static_prod_account_email = "static-prod@example.com"
 
 # Static Staging account email address
 static_stg_account_email = "static-stg@example.com"
+
+# Kidsword Production account email address
+kidsword_prod_account_email = "kidsword-prod@example.com"
+
+# Kidsword Staging account email address
+kidsword_stg_account_email = "kidsword-stg@example.com"

--- a/variables.tf
+++ b/variables.tf
@@ -15,3 +15,15 @@ variable "static_stg_account_email" {
   type        = string
   default     = "static-stg@example.com"
 }
+
+variable "kidsword_prod_account_email" {
+  description = "Email address for the kidsword production account"
+  type        = string
+  default     = "kidsword-prod@example.com"
+}
+
+variable "kidsword_stg_account_email" {
+  description = "Email address for the kidsword staging account"
+  type        = string
+  default     = "kidsword-stg@example.com"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.14.1"
+  required_version = "1.14.6"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## 変更内容

- `variables.tf`: kidsword prod/stg アカウント用メールアドレス変数を追加
- `organizations.tf`: kidsword-prod / kidsword-stg の AWS Organizations アカウントを追加
- `sso.tf`: adminグループへの AdministratorAccess 割り当てを kidsword prod/stg アカウントに追加
- `terraform.tfvars.example`: kidsword prod/stg のメールアドレスサンプルを追加
- `versions.tf`: Terraform バージョン制約を `1.14.1` → `1.14.6` に更新

Close #36