### PR TITLE
multibook用prod/stgアカウントを追加

### DIFF
--- a/organizations.tf
+++ b/organizations.tf
@@ -42,3 +42,19 @@ resource "aws_organizations_account" "kidsword_stg" {
 
   depends_on = [aws_organizations_organization.main]
 }
+
+# Multibook Production Account
+resource "aws_organizations_account" "multibook_prod" {
+  name  = "multibook-prod"
+  email = var.multibook_prod_account_email
+
+  depends_on = [aws_organizations_organization.main]
+}
+
+# Multibook Staging Account
+resource "aws_organizations_account" "multibook_stg" {
+  name  = "multibook-stg"
+  email = var.multibook_stg_account_email
+
+  depends_on = [aws_organizations_organization.main]
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -13,3 +13,9 @@ kidsword_prod_account_email = "kidsword-prod@example.com"
 
 # Kidsword Staging account email address
 kidsword_stg_account_email = "kidsword-stg@example.com"
+
+# Multibook Production account email address
+multibook_prod_account_email = "multibook-prod@example.com"
+
+# Multibook Staging account email address
+multibook_stg_account_email = "multibook-stg@example.com"

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,15 @@ variable "kidsword_stg_account_email" {
   type        = string
   default     = "kidsword-stg@example.com"
 }
+
+variable "multibook_prod_account_email" {
+  description = "Email address for the multibook production account"
+  type        = string
+  default     = "multibook-prod@example.com"
+}
+
+variable "multibook_stg_account_email" {
+  description = "Email address for the multibook staging account"
+  type        = string
+  default     = "multibook-stg@example.com"
+}


### PR DESCRIPTION
## 変更内容

- `organizations.tf`: multibook-prod / multibook-stg の Organizations アカウントリソースを追加
- `variables.tf`: `multibook_prod_account_email` / `multibook_stg_account_email` 変数を追加
- `terraform.tfvars.example`: サンプル値を追加

kidsword アカウントと同一のパターンで実装しています。

Close #38