### PR TITLE
feat: master.makedara.work のSES受信/転送/SMTP返信構成を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,50 @@ IAM Identity Center (旧AWS SSO) の有効化はTerraformでは実行できな�
    - ユーザーはIAM Identity Centerのログインページでユーザー名とワンタイムパスワードを入力してログイン
    - ログイン後、新しいパスワードの設定画面が表示されるので、新しいパスワードを設定して完了
 
+### 重要: master.makedara.work のメール受信/送信設定について
+
+`master.makedara.work` ドメインの問い合わせメール（`contact@master.makedara.work`）を
+SES で受信し、`abechinoid+master@gmail.com` へ転送、Gmail の「他のアドレスから送信」で
+`contact@` として返信できるようにする構成です。Route53 ホストゾーンの作成・親ドメインへの
+NS 委任・SES サンドボックス解除・Gmail 設定は Terraform 管理外のため、以下を手動で実施します。
+
+#### 実行手順
+
+1. **Route53 ホストゾーンを手動作成**
+   - マスターアカウントのコンソールで `master.makedara.work` の public hosted zone を作成
+   - 払い出された Zone ID を `terraform.tfvars` の `master_makedara_zone_id` に設定
+
+2. **親ドメインへ NS 委任**
+   - `makedara.work` を管理する DNS（レジストラ or 親ゾーン）に、手順1で払い出された
+     4 本の NS を持つ `master` サブドメインの NS レコードを追加して委任する
+
+3. **terraform apply（ユーザーが実行）**
+   ```bash
+   aws sso login --profile master
+   export AWS_PROFILE=master && terraform apply
+   ```
+   - SES identity・DKIM/MX/SPF/DMARC・受信用 S3・転送 Lambda・SMTP user が作成されます
+
+4. **DKIM 検証待ち**
+   - SES コンソールで identity が Verified になるまで待機（DNS 伝播後）
+
+5. **SES サンドボックス解除申請**
+   - 任意宛先（Gmail 転送・任意宛の返信）へ送るため、コンソール/サポートから
+     プロダクションアクセスを申請する
+
+6. **Gmail の「他のアドレスから送信」設定**
+   - 設定 → アカウント → 「他のメールアドレスを追加」→ `contact@master.makedara.work`
+   - SMTP サーバー: `email-smtp.ap-northeast-1.amazonaws.com`、ポート 587（TLS）
+   - ユーザー名/パスワード:
+     ```bash
+     terraform output -raw ses_smtp_username
+     terraform output -raw ses_smtp_password
+     ```
+
+7. **疎通確認**
+   - `contact@master.makedara.work` にテスト送信 → Gmail に転送されること
+   - Gmail から返信 → 元送信者に `contact@` 名義で届くことを確認
+
 ### Terraform初期化
 
 作業ディレクトリでTerraformを初期化します。環境変数 `AWS_PROFILE` でプロファイル名を指定してください。

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,8 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+# master.makedara.work の Route53 ホストゾーン（手動作成済み。Zone ID を tfvars で投入）。
+data "aws_route53_zone" "makedara" {
+  zone_id = var.master_makedara_zone_id
+}

--- a/lambda/ses-forward/index.mjs
+++ b/lambda/ses-forward/index.mjs
@@ -1,0 +1,153 @@
+// SES Inbound（メール受信）で S3 に保存された生メールを読み、宛先を運営の Gmail へ
+// 付け替えて SES で再送信（転送）する。AWS 公式パターン
+// 「Forward Incoming Email to an External Destination」に準拠する。
+//
+// nodejs22.x に同梱の AWS SDK v3 を使い、依存追加なし（自己完結の ESM）。
+//
+// 再送信時のポイント:
+// - From は必ず検証済み identity（CONTACT_MAIL_FROM = noreply@<domain>）に書き換える。
+//   SES は送信元 From を検証済みアドレスに限定するため、元 From のままでは送れない。
+// - 元の差出人は Reply-To に退避する（Gmail から返信すると相手本人に届く）。
+// - Return-Path / DKIM-Signature 等、再送で不整合になるヘッダは除去する。
+// - 本文・添付（multipart）はトップレベルヘッダのみ触るため保持される。
+// - バイト列は latin1（1:1 マッピング）で文字列化してヘッダのみ書き換え、そのまま
+//   バイト列へ戻すことで、base64/8bit を含む添付を壊さない。
+
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { SESClient, SendRawEmailCommand } from '@aws-sdk/client-ses';
+
+const s3 = new S3Client({ region: process.env.AWS_REGION });
+const ses = new SESClient({ region: process.env.AWS_REGION });
+
+// 再送信時に取り除くヘッダ（小文字で比較）。元メールの認証・経路情報は転送後に無効。
+const HEADERS_TO_STRIP = new Set([
+  'return-path',
+  'sender',
+  'message-id',
+  'dkim-signature',
+  'authentication-results',
+  'received-spf',
+  'received',
+  'arc-authentication-results',
+  'arc-message-signature',
+  'arc-seal',
+]);
+
+// ヘッダブロックと本文を最初の空行で分割する。CRLF / LF のどちらにも対応する。
+function splitHeadersAndBody(raw) {
+  const crlf = raw.indexOf('\r\n\r\n');
+  if (crlf !== -1) {
+    return { headerBlock: raw.slice(0, crlf), body: raw.slice(crlf + 4), eol: '\r\n' };
+  }
+  const lf = raw.indexOf('\n\n');
+  if (lf !== -1) {
+    return { headerBlock: raw.slice(0, lf), body: raw.slice(lf + 2), eol: '\n' };
+  }
+  return { headerBlock: raw, body: '', eol: '\r\n' };
+}
+
+// 折り返し（先頭が空白の継続行）を 1 エントリにまとめてヘッダを列挙する。
+function parseHeaderEntries(headerBlock, eol) {
+  const entries = [];
+  for (const line of headerBlock.split(/\r?\n/)) {
+    if (/^[ \t]/.test(line) && entries.length > 0) {
+      entries[entries.length - 1] += eol + line;
+    } else {
+      entries.push(line);
+    }
+  }
+  return entries.filter((e) => e.trim() !== '');
+}
+
+function headerName(entry) {
+  const colon = entry.indexOf(':');
+  return colon === -1 ? '' : entry.slice(0, colon).trim().toLowerCase();
+}
+
+// 生メール（latin1 文字列）のヘッダを転送用に書き換えて返す。
+export function rewriteForForwarding(raw, fromAddress) {
+  const { headerBlock, body, eol } = splitHeadersAndBody(raw);
+  const entries = parseHeaderEntries(headerBlock, eol);
+
+  let originalFrom;
+  let hasReplyTo = false;
+  const kept = [];
+
+  for (const entry of entries) {
+    const name = headerName(entry);
+    if (name === 'from') {
+      // 折り返しを 1 行に畳んで元 From を退避しつつ、From 自体は差し替える。
+      originalFrom = entry
+        .slice(entry.indexOf(':') + 1)
+        .replace(/\r?\n[ \t]+/g, ' ')
+        .trim();
+      kept.push(`From: contact <${fromAddress}>`);
+      continue;
+    }
+    if (name === 'reply-to') {
+      hasReplyTo = true;
+      kept.push(entry);
+      continue;
+    }
+    if (HEADERS_TO_STRIP.has(name)) {
+      continue;
+    }
+    kept.push(entry);
+  }
+
+  // 元メールに Reply-To が無ければ、元差出人を Reply-To に設定する。
+  if (!hasReplyTo && originalFrom) {
+    kept.unshift(`Reply-To: ${originalFrom}`);
+  }
+
+  return kept.join(eol) + eol + eol + body;
+}
+
+// messageId をキーに S3 から生メールを取得し、転送用に書き換えて SES で再送信する。
+async function forwardInboundEmail(messageId) {
+  const bucket = process.env.SES_INBOUND_BUCKET;
+  const prefix = process.env.SES_INBOUND_PREFIX ?? '';
+  const fromAddress = process.env.CONTACT_MAIL_FROM;
+  const forwardTo = process.env.CONTACT_FORWARD_TO;
+
+  if (!bucket) throw new Error('SES_INBOUND_BUCKET is not set');
+  if (!fromAddress) throw new Error('CONTACT_MAIL_FROM is not set');
+  if (!forwardTo) throw new Error('CONTACT_FORWARD_TO is not set');
+
+  const key = `${prefix}${messageId}`;
+
+  const object = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+  if (!object.Body) {
+    throw new Error(`Inbound email object has empty body: s3://${bucket}/${key}`);
+  }
+  const bytes = await object.Body.transformToByteArray();
+  // latin1 は 1 バイト = 1 コードポイントで往復可能。添付のバイト列を壊さない。
+  const raw = Buffer.from(bytes).toString('latin1');
+
+  const forwarded = rewriteForForwarding(raw, fromAddress);
+
+  await ses.send(
+    new SendRawEmailCommand({
+      Source: fromAddress,
+      Destinations: [forwardTo],
+      RawMessage: { Data: Buffer.from(forwarded, 'latin1') },
+    }),
+  );
+
+  console.info(JSON.stringify({ msg: 'forwarded inbound email', messageId, key, forwardTo }));
+}
+
+// SES Inbound の受信ルール（LambdaAction）から起動される転送ハンドラ。
+// 受信ルールは事前に S3Action で生メールを s3://<bucket>/<prefix><messageId> に保存済み。
+export const handler = async (event) => {
+  for (const record of event.Records) {
+    const messageId = record.ses.mail.messageId;
+    try {
+      await forwardInboundEmail(messageId);
+    } catch (err) {
+      // throw して非同期起動のリトライ／失敗として扱う（原因調査は CloudWatch Logs で行う）。
+      console.error(JSON.stringify({ msg: 'failed to forward inbound email', messageId, err: String(err) }));
+      throw err;
+    }
+  }
+};

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  makedara_domain    = "master.makedara.work"
+  contact_mail_to    = "contact@${local.makedara_domain}" # 受信 & Gmail 返信の名乗り
+  contact_mail_from  = "noreply@${local.makedara_domain}" # 転送 Lambda の書換後 From
+  ses_inbound_prefix = "inbound/"
+
+  # 受信バケット名の UUID を一元管理（グローバル一意にするため固定 UUID を付与）。
+  ses_inbound_bucket_uuid = "03da39ab-5aab-44cd-afef-43666e52e62d"
+  ses_inbound_bucket_name = "master-ses-inbound-${local.ses_inbound_bucket_uuid}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,20 @@
+output "ses_smtp_endpoint" {
+  description = "Gmail の Send mail as に設定する SES SMTP サーバ（ポート 587 / STARTTLS）"
+  value       = "email-smtp.${data.aws_region.current.region}.amazonaws.com"
+}
+
+output "ses_smtp_username" {
+  description = "SES SMTP ユーザ名（IAM アクセスキー ID）"
+  value       = aws_iam_access_key.ses_smtp.id
+}
+
+output "ses_smtp_password" {
+  description = "SES SMTP パスワード（access key secret を SigV4 で導出した値）"
+  value       = aws_iam_access_key.ses_smtp.ses_smtp_password_v4
+  sensitive   = true
+}
+
+output "ses_inbound_bucket" {
+  description = "SES Inbound で受信した生メールを保存する S3 バケット名"
+  value       = aws_s3_bucket.ses_inbound.bucket
+}

--- a/route53.tf
+++ b/route53.tf
@@ -1,0 +1,22 @@
+# ---------------------------------------------------------------------------
+# 送信到達性向上のための DNS レコード（SPF / DMARC）。
+# DKIM CNAME・MX は ses.tf / ses-inbound.tf 側で管理する。
+# ---------------------------------------------------------------------------
+
+# SPF: SES を正規の送信元として宣言する（apex に TXT）。
+resource "aws_route53_record" "spf" {
+  zone_id = data.aws_route53_zone.makedara.zone_id
+  name    = local.makedara_domain
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=spf1 include:amazonses.com ~all"]
+}
+
+# DMARC: 監視モード（p=none）。集約レポートを転送先へ送る。
+resource "aws_route53_record" "dmarc" {
+  zone_id = data.aws_route53_zone.makedara.zone_id
+  name    = "_dmarc.${local.makedara_domain}"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=DMARC1; p=none; rua=mailto:${var.contact_forward_to}"]
+}

--- a/ses-inbound.tf
+++ b/ses-inbound.tf
@@ -1,0 +1,261 @@
+# ---------------------------------------------------------------------------
+# SES Inbound（メール受信）: contact@master.makedara.work 宛メールを S3 に保存し、
+# 転送 Lambda で運営者の Gmail へ転送する。AWS 公式パターン「Forward Incoming Email
+# to an External Destination」（受信 → S3 保存 → Lambda が S3 から生メールを読み再送信）
+# に準拠する。
+#
+# リージョンは既定 provider（ap-northeast-1）。SES のメール受信は東京リージョンで利用可能で、
+# ses.tf のドメイン identity / DKIM と data.aws_route53_zone.makedara をそのまま流用する。
+# active receipt rule set はアカウント×リージョンで 1 つ（マスターアカウントは SES 未使用のため競合しない想定）。
+# ---------------------------------------------------------------------------
+
+# --- 受信メール保存用 S3 バケット -------------------------------------------
+
+resource "aws_s3_bucket" "ses_inbound" {
+  bucket = local.ses_inbound_bucket_name
+}
+
+resource "aws_s3_bucket_ownership_controls" "ses_inbound" {
+  bucket = aws_s3_bucket.ses_inbound.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "ses_inbound" {
+  bucket = aws_s3_bucket.ses_inbound.id
+
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "ses_inbound" {
+  bucket = aws_s3_bucket.ses_inbound.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      # SSE-S3（AES256）。SSE-KMS にすると SES 側に KMS 権限が別途必要になるため使わない。
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "ses_inbound" {
+  bucket = aws_s3_bucket.ses_inbound.id
+
+  # 未完了のマルチパートアップロードを 7 日後に中止（標準的な衛生設定）
+  rule {
+    id     = "abort-incomplete-multipart-upload"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  # メールは Gmail へ転送されるため S3 は保険。365 日で失効させ保存容量を上限化する。
+  rule {
+    id     = "expire-inbound-emails"
+    status = "Enabled"
+
+    filter {
+      prefix = local.ses_inbound_prefix
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+
+# SES がこのバケットへ受信メールを書き込めるようにするバケットポリシー。
+# 受信ルール作成時に SES が書き込み可否を検証するため、ルールより先に存在させる（下記 depends_on）。
+data "aws_iam_policy_document" "ses_inbound_bucket" {
+  statement {
+    sid       = "AllowSESPuts"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.ses_inbound.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ses.amazonaws.com"]
+    }
+
+    # 自アカウントの SES からの書き込みだけを許可する（混乱した代理人問題の防止）。
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    # さらに本受信ルールセット配下のルールに限定する（ARN は文字列構築で循環参照を避ける）。
+    condition {
+      test     = "StringLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:ses:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:receipt-rule-set/master-contact:receipt-rule/*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "ses_inbound" {
+  bucket = aws_s3_bucket.ses_inbound.id
+  policy = data.aws_iam_policy_document.ses_inbound_bucket.json
+}
+
+# --- MX レコード（このドメイン宛メールを SES 受信に向ける）-------------------
+
+resource "aws_route53_record" "ses_mx" {
+  zone_id = data.aws_route53_zone.makedara.zone_id
+  name    = local.makedara_domain
+  type    = "MX"
+  ttl     = 300
+  records = ["10 inbound-smtp.${data.aws_region.current.region}.amazonaws.com"]
+}
+
+# --- 転送 Lambda -----------------------------------------------------------
+
+data "archive_file" "ses_forward" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda/ses-forward"
+  output_path = "${path.module}/.terraform/tmp/ses-forward.zip"
+}
+
+resource "aws_cloudwatch_log_group" "ses_forward" {
+  name              = "/aws/lambda/master-ses-forward"
+  retention_in_days = 14
+}
+
+# Lambda 実行ロールの信頼ポリシー。
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+# 転送 Lambda 専用の実行ロール（最小権限）。
+resource "aws_iam_role" "ses_forward" {
+  name               = "master-ses-forward-exec"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ses_forward_basic_execution" {
+  role       = aws_iam_role.ses_forward.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "ses_forward_inline" {
+  statement {
+    sid       = "S3GetInboundEmail"
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.ses_inbound.arn}/${local.ses_inbound_prefix}*"]
+  }
+
+  statement {
+    sid    = "SESForwardSend"
+    effect = "Allow"
+    # 転送 Lambda は SendRawEmail（生 MIME）で再送信する。
+    # 将来 Simple content 送信を足しても壊れないよう ses:SendEmail も許可する。
+    actions = ["ses:SendEmail", "ses:SendRawEmail"]
+    # サンドボックスでは宛先 identity の認可も評価されるためリージョン内の全 identity を
+    # 対象にしつつ、ses:FromAddress 条件で送信元を noreply@ に固定する（554 対策）。
+    resources = ["arn:aws:ses:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:identity/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ses:FromAddress"
+      values   = [local.contact_mail_from]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "ses_forward_inline" {
+  name   = "master-ses-forward-inline"
+  role   = aws_iam_role.ses_forward.id
+  policy = data.aws_iam_policy_document.ses_forward_inline.json
+}
+
+resource "aws_lambda_function" "ses_forward" {
+  function_name = "master-ses-forward"
+  role          = aws_iam_role.ses_forward.arn
+  runtime       = "nodejs22.x"
+  handler       = "index.handler"
+  architectures = ["arm64"]
+
+  filename         = data.archive_file.ses_forward.output_path
+  source_code_hash = data.archive_file.ses_forward.output_base64sha256
+
+  timeout     = 30
+  memory_size = 256
+
+  environment {
+    variables = {
+      CONTACT_MAIL_FROM  = local.contact_mail_from
+      CONTACT_FORWARD_TO = var.contact_forward_to
+      SES_INBOUND_BUCKET = aws_s3_bucket.ses_inbound.bucket
+      SES_INBOUND_PREFIX = local.ses_inbound_prefix
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.ses_forward]
+}
+
+# SES 受信ルールがこの Lambda を起動できるようにする。
+resource "aws_lambda_permission" "ses_forward" {
+  statement_id   = "AllowSESInvoke"
+  action         = "lambda:InvokeFunction"
+  function_name  = aws_lambda_function.ses_forward.function_name
+  principal      = "ses.amazonaws.com"
+  source_account = data.aws_caller_identity.current.account_id
+}
+
+# --- 受信ルールセット / ルール ---------------------------------------------
+# 受信系は v1 リソース（aws_sesv2_* に受信系は無い）。
+
+resource "aws_ses_receipt_rule_set" "this" {
+  rule_set_name = "master-contact"
+}
+
+resource "aws_ses_active_receipt_rule_set" "this" {
+  rule_set_name = aws_ses_receipt_rule_set.this.rule_set_name
+}
+
+resource "aws_ses_receipt_rule" "contact" {
+  name          = "master-contact-rule"
+  rule_set_name = aws_ses_receipt_rule_set.this.rule_set_name
+  recipients    = [local.contact_mail_to]
+  enabled       = true
+  scan_enabled  = true
+  tls_policy    = "Require"
+
+  # アクションは順序が重要。まず S3 に保存し、その後で転送 Lambda を起動する。
+  s3_action {
+    bucket_name       = aws_s3_bucket.ses_inbound.bucket
+    object_key_prefix = local.ses_inbound_prefix
+    position          = 1
+  }
+
+  lambda_action {
+    function_arn    = aws_lambda_function.ses_forward.arn
+    invocation_type = "Event"
+    position        = 2
+  }
+
+  # SES が S3 書き込み / Lambda 起動できる権限が先に存在しないと apply が失敗するため依存を張る。
+  depends_on = [
+    aws_s3_bucket_policy.ses_inbound,
+    aws_lambda_permission.ses_forward,
+  ]
+}

--- a/ses-smtp.tf
+++ b/ses-smtp.tf
@@ -1,0 +1,45 @@
+# =============================================================================
+# SES SMTP 送信用の認証情報（Gmail の「他のアドレスから送信」返信用）
+# =============================================================================
+# 目的: Gmail の「他のアドレスから送信（Send mail as）」の送信 SMTP サーバとして SES を使い、
+#       問い合わせ（contact@master.makedara.work）への返信 From を contact@ にできるようにする。
+#       個人 Gmail アドレスを相手に露出させないための構成。
+#
+# 仕組み: SES の SMTP インターフェースは IAM 認証情報を SMTP ユーザ名／パスワードに変換して使う。
+#         SMTP 経由の送信は内部的に `ses:SendRawEmail` として評価される。SMTP パスワードは
+#         access key の secret を SigV4 で導出した専用文字列で、`ses_smtp_password_v4` 属性から取得する。
+#
+# 注意: 任意の宛先（問い合わせ者）へ返信するには SES プロダクションアクセス（サンドボックス解除）が必要。
+
+resource "aws_iam_user" "ses_smtp" {
+  name = "master-ses-smtp"
+}
+
+resource "aws_iam_access_key" "ses_smtp" {
+  user = aws_iam_user.ses_smtp.name
+}
+
+data "aws_iam_policy_document" "ses_smtp_send" {
+  statement {
+    sid     = "SESSmtpSendRaw"
+    effect  = "Allow"
+    actions = ["ses:SendRawEmail"]
+    # サンドボックスでは受信者（To）identity の認可も評価されるため、リージョン内の全 identity を
+    # 対象にしつつ、下の ses:FromAddress 条件で送信元を contact@ に固定する（554 対策）。
+    # ドメイン identity のみに絞ると、検証済み受信者宛でも受信者 identity の認可で弾かれ 554 になる。
+    resources = ["arn:aws:ses:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:identity/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ses:FromAddress"
+      # From を contact@ に固定する。Gmail の Send mail as 認証時に From が異なるとブロックされ得る。
+      values = [local.contact_mail_to]
+    }
+  }
+}
+
+resource "aws_iam_user_policy" "ses_smtp_send" {
+  name   = "master-ses-smtp-send"
+  user   = aws_iam_user.ses_smtp.name
+  policy = data.aws_iam_policy_document.ses_smtp_send.json
+}

--- a/ses.tf
+++ b/ses.tf
@@ -1,0 +1,27 @@
+# ---------------------------------------------------------------------------
+# SES ドメイン identity + Easy DKIM
+# master.makedara.work をドメイン identity として登録し、Easy DKIM の CNAME 3 件を
+# Route53 に登録して検証する（_amazonses TXT 検証は不要）。
+# ---------------------------------------------------------------------------
+
+resource "aws_sesv2_email_identity" "makedara" {
+  email_identity = local.makedara_domain
+
+  dkim_signing_attributes {
+    next_signing_key_length = "RSA_2048_BIT"
+  }
+}
+
+# SES が発行する DKIM 用 CNAME レコード（3 件）を Route53 に登録する。
+# Easy DKIM は常に 3 トークンを生成するため count = 3 で固定する。
+# （for_each はキーがトークン値=apply 時まで unknown のため使用不可）
+# DKIM 検証が完了すると SES identity の dkim_status が SUCCESS になる。
+resource "aws_route53_record" "ses_dkim" {
+  count = 3
+
+  zone_id = data.aws_route53_zone.makedara.zone_id
+  name    = "${aws_sesv2_email_identity.makedara.dkim_signing_attributes[0].tokens[count.index]}._domainkey.${local.makedara_domain}"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["${aws_sesv2_email_identity.makedara.dkim_signing_attributes[0].tokens[count.index]}.dkim.amazonses.com"]
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -25,3 +25,9 @@ sandbox_01_account_email = "sandbox-01@example.com"
 
 # Sandbox-02 account email address
 sandbox_02_account_email = "sandbox-02@example.com"
+
+# master.makedara.work の Route53 ホストゾーンID（手動作成後に投入）
+master_makedara_zone_id = "ZXXXXXXXXXXXXX"
+
+# 問い合わせメール（contact@master.makedara.work）の転送先
+contact_forward_to = "abechinoid+master@gmail.com"

--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,15 @@ variable "sandbox_02_account_email" {
   type        = string
   default     = "sandbox-02@example.com"
 }
+
+variable "master_makedara_zone_id" {
+  description = "master.makedara.work の Route53 ホストゾーンID（手動作成後に投入）"
+  type        = string
+  default     = ""
+}
+
+variable "contact_forward_to" {
+  description = "問い合わせメールの転送先"
+  type        = string
+  default     = "abechinoid+master@gmail.com"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "6.26.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
   }
 }


### PR DESCRIPTION
## 概要

`master.makedara.work` ドメインを Route53 で管理し、`contact@master.makedara.work` 宛の
問い合わせメールを Amazon SES Inbound で受信 → S3 保存 + Lambda で `abechinoid+master@gmail.com`
へ転送し、Gmail の「他のアドレスから送信」で送信元を隠して `contact@` として返信できる
SMTP クレデンシャルを整備する。過去に別アカウントで発生した `554 ses:SendRawEmail` エラー
（kidsword で検証済みの対策）を移植して再発を防ぐ。

## 変更内容

- `ses.tf`: SESv2 ドメイン identity + Easy DKIM CNAME × 3
- `ses-inbound.tf`: 受信用 S3（UUID 付きバケット名 / SSE-S3 / lifecycle / public access block）+
  bucket policy、MX レコード、転送 Lambda（専用 IAM role/policy・log group・permission）、
  receipt rule set / active rule set / receipt rule（s3_action → lambda_action）
- `ses-smtp.tf`: Gmail 返信用 IAM user + access key + user policy（**554 対策**: `identity/*` +
  `ses:FromAddress = contact@` 条件）
- `route53.tf`: SPF(TXT) / DMARC(TXT)
- `lambda/ses-forward/index.mjs`: 自己完結の ESM 転送 forwarder（S3 生 MIME を latin1 で往復し
  From 書換・元 From を Reply-To に退避・経路/署名系ヘッダ除去 → `SendRawEmail` で再送信）
- `locals.tf` / `data.tf` / `outputs.tf` / `variables.tf` / `terraform.tfvars.example` / `versions.tf`
  （archive provider 追加）/ `README.md`（手動手順追記）

## 設計

- 対応 plan: `.claude/plans/issue-46-master-makedara-ses.md`

## 動作確認

- `terraform fmt -check`（新規/変更ファイル）: 通過
- `terraform validate`（backend 無しのクリーン環境）: `Success! The configuration is valid.`
- `node --check lambda/ses-forward/index.mjs`: 通過
- `terraform plan` / `apply` および E2E（受信→S3保存→Gmail転送→Gmail返信）はユーザーが実施
  （Route53 ホストゾーン作成・NS 委任・サンドボックス解除・Gmail 設定は README の手動手順参照）

Close #46
