### PR TITLE
Abenotech 事業紹介サイト（pages.master.makedara.work）の構築

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,59 @@ NS 委任・SES サンドボックス解除・Gmail 設定は Terraform 管理�
    - `contact@master.makedara.work` にテスト送信 → Gmail に転送されること
    - Gmail から返信 → 元送信者に `contact@` 名義で届くことを確認
 
+### 重要: Abenotech 事業紹介サイト（pages.master.makedara.work）について
+
+`https://pages.master.makedara.work/` で事業紹介サイト（静的 3 ページ）を配信し、問い合わせ
+フォームは Cloudflare Turnstile で Bot を弾いたうえで SES メール通知します。配信は
+CloudFront + S3（OAC）、問い合わせ API は API Gateway + Lambda 構成です。
+静的コンテンツ（`web/` 配下）は Terraform では管理せず、`scripts/deploy-pages.sh` で配置します。
+Turnstile ウィジェットの作成・シークレット投入・HTML への値埋め込みは手動で実施します。
+
+#### 実行手順
+
+1. **Cloudflare Turnstile ウィジェットを作成**
+   - Cloudflare ダッシュボード → Turnstile で `pages.master.makedara.work` 用ウィジェットを追加
+   - 払い出された **Site Key**（公開値）と **Secret Key**（機密値）を控える
+
+2. **terraform apply（ユーザーが実行）**
+   ```bash
+   aws sso login --profile master
+   export AWS_PROFILE=master && terraform apply
+   ```
+   - 配信用 S3・CloudFront・ACM 証明書（us-east-1・DNS 検証は Route53 で自動）・
+     問い合わせ API（API Gateway + Lambda）・Turnstile シークレット用 SSM パラメータが作成されます
+   - ACM は DNS 検証完了まで apply が待機します（数分）
+
+3. **Turnstile シークレットを SSM に投入**
+   ```bash
+   export AWS_PROFILE=master
+   aws ssm put-parameter \
+     --name /master/turnstile/secret-key \
+     --type SecureString --overwrite \
+     --value '<Cloudflare の Secret Key>'
+   ```
+
+4. **HTML にサイト固有値を埋め込む**
+   - `web/contact.html` の `__TURNSTILE_SITE_KEY__` を手順1の Site Key に置換
+   - `web/contact.html` の `__API_BASE__` を API エンドポイントに置換:
+     ```bash
+     terraform output -raw contact_api_endpoint
+     ```
+
+5. **静的コンテンツをデプロイ**
+   ```bash
+   export AWS_PROFILE=master && ./scripts/deploy-pages.sh
+   ```
+   - `web/` を配信バケットへ同期し、CloudFront キャッシュを無効化します
+
+6. **疎通確認**
+   - `https://pages.master.makedara.work/` が HTTPS で表示され、3 ページを相互遷移できること
+   - 問い合わせフォームで Turnstile を通過し送信 → `contact@master.makedara.work` に通知が届き、
+     既存の転送で運営 Gmail に届くこと。その返信が送信者に届くこと（Reply-To）
+
+> 補足: 問い合わせ通知の宛先は検証済みの `contact@master.makedara.work` のため、
+> SES サンドボックスのままでも通知メールは送信されます（既存の受信転送に相乗り）。
+
 ### Terraform初期化
 
 作業ディレクトリでTerraformを初期化します。環境変数 `AWS_PROFILE` でプロファイル名を指定してください。

--- a/contact-api.tf
+++ b/contact-api.tf
@@ -1,0 +1,180 @@
+# ---------------------------------------------------------------------------
+# 問い合わせ API: API Gateway HTTP API + Lambda。
+# サイト（pages.master.makedara.work）の問い合わせフォームから POST /contact を受け、
+# Cloudflare Turnstile 検証後に SES で運営宛通知メールを送信する。
+#
+# Lambda は lambda/contact/index.mjs（依存追加なしの自己完結 ESM。lambda/ses-forward と同方針）。
+# SES 送信先 contact@ は既存 SES 受信転送に乗るため、SES 側の新規設定は不要。
+# ---------------------------------------------------------------------------
+
+# --- Lambda パッケージ ------------------------------------------------------
+
+data "archive_file" "contact" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda/contact"
+  output_path = "${path.module}/.terraform/tmp/contact.zip"
+}
+
+resource "aws_cloudwatch_log_group" "contact" {
+  name              = "/aws/lambda/master-contact"
+  retention_in_days = 14
+}
+
+# --- Turnstile シークレット（SSM SecureString・実値は apply 後に手動投入）------
+
+resource "aws_ssm_parameter" "turnstile_secret" {
+  name        = "/master/turnstile/secret-key"
+  description = "Cloudflare Turnstile secret key for pages.master.makedara.work. Set manually via AWS CLI."
+  type        = "SecureString"
+  value       = "PLACEHOLDER_REPLACE_MANUALLY"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+# --- Lambda 実行ロール（最小権限）------------------------------------------
+# 信頼ポリシー data.aws_iam_policy_document.lambda_assume_role は ses-inbound.tf で定義済みを流用する。
+
+resource "aws_iam_role" "contact" {
+  name               = "master-contact-exec"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "contact_basic_execution" {
+  role       = aws_iam_role.contact.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "contact_inline" {
+  # SES 送信（From を noreply@ に固定）。ses-inbound.tf の SESForwardSend と同じ作法。
+  statement {
+    sid       = "SESSendNotification"
+    effect    = "Allow"
+    actions   = ["ses:SendEmail"]
+    resources = ["arn:aws:ses:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:identity/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ses:FromAddress"
+      values   = [local.contact_mail_from]
+    }
+  }
+
+  # Turnstile シークレット（SecureString）の取得。
+  statement {
+    sid       = "SSMGetTurnstileSecret"
+    effect    = "Allow"
+    actions   = ["ssm:GetParameter"]
+    resources = [aws_ssm_parameter.turnstile_secret.arn]
+  }
+
+  # SecureString 復号（SSM の AWS 管理キー経由のみに限定）。
+  statement {
+    sid       = "KMSDecryptViaSSM"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${data.aws_region.current.region}.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "contact_inline" {
+  name   = "master-contact-inline"
+  role   = aws_iam_role.contact.id
+  policy = data.aws_iam_policy_document.contact_inline.json
+}
+
+# --- Lambda 関数 ------------------------------------------------------------
+
+resource "aws_lambda_function" "contact" {
+  function_name = "master-contact"
+  role          = aws_iam_role.contact.arn
+  runtime       = "nodejs22.x"
+  handler       = "index.handler"
+  architectures = ["arm64"]
+
+  filename         = data.archive_file.contact.output_path
+  source_code_hash = data.archive_file.contact.output_base64sha256
+
+  timeout     = 15
+  memory_size = 256
+
+  environment {
+    variables = {
+      CONTACT_MAIL_FROM         = local.contact_mail_from
+      CONTACT_MAIL_TO           = local.contact_mail_to
+      CONTACT_MAIL_SUBJECT      = local.contact_mail_subject
+      TURNSTILE_SECRET_SSM_NAME = aws_ssm_parameter.turnstile_secret.name
+      ALLOW_ORIGIN              = "https://${local.pages_domain}"
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.contact]
+}
+
+# --- API Gateway HTTP API ---------------------------------------------------
+
+resource "aws_apigatewayv2_api" "contact" {
+  name          = "master-contact"
+  protocol_type = "HTTP"
+  description   = "Contact form API for ${local.pages_domain}"
+
+  # 問い合わせフォーム（サイト本体オリジン）からのブラウザアクセスのみ許可する。
+  cors_configuration {
+    allow_origins = ["https://${local.pages_domain}"]
+    allow_methods = ["POST", "OPTIONS"]
+    allow_headers = ["content-type"]
+    max_age       = 3600
+  }
+}
+
+resource "aws_apigatewayv2_integration" "contact" {
+  api_id                 = aws_apigatewayv2_api.contact.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.contact.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "contact" {
+  api_id    = aws_apigatewayv2_api.contact.id
+  route_key = "POST /contact"
+  target    = "integrations/${aws_apigatewayv2_integration.contact.id}"
+}
+
+resource "aws_cloudwatch_log_group" "contact_apigw" {
+  name              = "/aws/apigateway/master-contact"
+  retention_in_days = 14
+}
+
+resource "aws_apigatewayv2_stage" "contact" {
+  api_id      = aws_apigatewayv2_api.contact.id
+  name        = "$default"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.contact_apigw.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      routeKey       = "$context.routeKey"
+      status         = "$context.status"
+      responseLength = "$context.responseLength"
+    })
+  }
+}
+
+resource "aws_lambda_permission" "contact_apigw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.contact.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.contact.execution_arn}/*/*"
+}

--- a/lambda/contact/index.mjs
+++ b/lambda/contact/index.mjs
@@ -1,0 +1,151 @@
+// Abenotech 事業紹介サイトの問い合わせ API。
+// API Gateway HTTP API（POST /contact）から起動され、次を行う:
+//   1. リクエストボディ {email, message, turnstileToken} を検証
+//   2. Cloudflare Turnstile のサーバ側検証（siteverify）で Bot を弾く
+//   3. SES で運営宛（contact@）へ通知メールを送信（Reply-To に問い合わせ者を設定）
+//
+// nodejs22.x 同梱の AWS SDK v3 を使い、依存追加なしの自己完結 ESM（lambda/ses-forward と同方針）。
+//
+// メール到達フロー（既存資産の再利用）:
+//   From = noreply@<domain>（検証済み）/ To = contact@<domain>（検証済み identity）。
+//   contact@ 宛は既存 SES 受信ルール（ses-inbound.tf）が S3 保存 → 転送 Lambda → 運営 Gmail。
+//   Reply-To に問い合わせ者を入れておくことで、Gmail からの返信が本人に届く（既存 SMTP 返信構成）。
+
+import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
+import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
+
+const SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+
+const ses = new SESv2Client({ region: process.env.AWS_REGION });
+const ssm = new SSMClient({ region: process.env.AWS_REGION });
+
+// 許可オリジン（CORS レスポンスヘッダ用）。
+const ALLOW_ORIGIN = process.env.ALLOW_ORIGIN;
+
+// Turnstile シークレットはモジュールスコープでキャッシュ（コールドスタート後 1 回だけ取得）。
+let secretPromise = null;
+
+function getTurnstileSecret() {
+  if (!secretPromise) {
+    secretPromise = (async () => {
+      try {
+        const name = process.env.TURNSTILE_SECRET_SSM_NAME;
+        const res = await ssm.send(new GetParameterCommand({ Name: name, WithDecryption: true }));
+        const value = res.Parameter?.Value;
+        if (!value) {
+          throw new Error(`SSM parameter is empty: ${name}`);
+        }
+        return value;
+      } catch (e) {
+        secretPromise = null; // 失敗はキャッシュしない（次回リトライ可能に）。
+        throw e;
+      }
+    })();
+  }
+  return secretPromise;
+}
+
+// Cloudflare siteverify にトークンを送り、成功なら true。トークン不正・期限切れ等は false。
+// ネットワーク断・SSM 取得失敗などの想定外は throw（呼び出し側で 500）。
+async function verifyTurnstileToken(token, remoteIp) {
+  const secret = await getTurnstileSecret();
+
+  const params = new URLSearchParams();
+  params.set('secret', secret);
+  params.set('response', token);
+  if (remoteIp) {
+    params.set('remoteip', remoteIp);
+  }
+
+  const res = await fetch(SITEVERIFY_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+
+  const data = await res.json();
+  if (data.success !== true) {
+    console.warn('turnstile verification failed', JSON.stringify(data['error-codes'] ?? []));
+    return false;
+  }
+  return true;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function corsHeaders() {
+  return {
+    'content-type': 'application/json',
+    'access-control-allow-origin': ALLOW_ORIGIN,
+    'access-control-allow-methods': 'POST,OPTIONS',
+    'access-control-allow-headers': 'content-type',
+  };
+}
+
+function response(statusCode, body) {
+  return { statusCode, headers: corsHeaders(), body: JSON.stringify(body) };
+}
+
+export const handler = async (event) => {
+  // CORS プリフライト（HTTP API の CORS 設定が主だが保険として応答）。
+  const method = event?.requestContext?.http?.method;
+  if (method === 'OPTIONS') {
+    return response(204, {});
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event?.body ?? '{}');
+  } catch {
+    return response(400, { ok: false, error: 'invalid JSON body' });
+  }
+
+  const email = typeof body.email === 'string' ? body.email.trim() : '';
+  const message = typeof body.message === 'string' ? body.message.trim() : '';
+  const turnstileToken = typeof body.turnstileToken === 'string' ? body.turnstileToken : '';
+
+  if (!EMAIL_RE.test(email) || email.length > 254) {
+    return response(400, { ok: false, error: 'invalid email' });
+  }
+  if (message.length < 10 || message.length > 2000) {
+    return response(400, { ok: false, error: 'invalid message' });
+  }
+  if (!turnstileToken) {
+    return response(400, { ok: false, error: 'missing turnstile token' });
+  }
+
+  const sourceIp = event?.requestContext?.http?.sourceIp;
+  const verified = await verifyTurnstileToken(turnstileToken, sourceIp);
+  if (!verified) {
+    return response(400, { ok: false, error: 'turnstile verification failed' });
+  }
+
+  const from = process.env.CONTACT_MAIL_FROM;
+  const to = process.env.CONTACT_MAIL_TO;
+  const subject = process.env.CONTACT_MAIL_SUBJECT;
+
+  const text = [
+    'Abenotech サイトのお問い合わせフォームから送信がありました。',
+    '',
+    `メールアドレス: ${email}`,
+    '',
+    'お問い合わせ内容:',
+    message,
+  ].join('\n');
+
+  await ses.send(
+    new SendEmailCommand({
+      FromEmailAddress: from,
+      Destination: { ToAddresses: [to] },
+      ReplyToAddresses: [email],
+      Content: {
+        Simple: {
+          Subject: { Data: subject, Charset: 'UTF-8' },
+          Body: { Text: { Data: text, Charset: 'UTF-8' } },
+        },
+      },
+    })
+  );
+
+  return response(200, { ok: true });
+};

--- a/locals.tf
+++ b/locals.tf
@@ -7,4 +7,14 @@ locals {
   # 受信バケット名の UUID を一元管理（グローバル一意にするため固定 UUID を付与）。
   ses_inbound_bucket_uuid = "03da39ab-5aab-44cd-afef-43666e52e62d"
   ses_inbound_bucket_name = "master-ses-inbound-${local.ses_inbound_bucket_uuid}"
+
+  # Abenotech 事業紹介サイト（pages.master.makedara.work）。
+  pages_domain = "pages.${local.makedara_domain}"
+
+  # 配信バケット名の UUID を一元管理（グローバル一意にするため固定 UUID を付与）。
+  pages_bucket_uuid = "fd50acc4-0697-427a-a30f-3a03e12a4bb6"
+  pages_bucket_name = "pages-${local.pages_bucket_uuid}"
+
+  # 問い合わせ通知メールの件名。
+  contact_mail_subject = "【Abenotech】お問い合わせ"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,3 +18,20 @@ output "ses_inbound_bucket" {
   description = "SES Inbound で受信した生メールを保存する S3 バケット名"
   value       = aws_s3_bucket.ses_inbound.bucket
 }
+
+# --- Abenotech 事業紹介サイト ----------------------------------------------
+
+output "pages_bucket_name" {
+  description = "サイト配信用 S3 バケット名（deploy-pages.sh の同期先）"
+  value       = aws_s3_bucket.pages.bucket
+}
+
+output "pages_cloudfront_distribution_id" {
+  description = "サイト配信 CloudFront ディストリビューション ID（invalidation 用）"
+  value       = aws_cloudfront_distribution.pages.id
+}
+
+output "contact_api_endpoint" {
+  description = "問い合わせ API のエンドポイント（web/contact.html の __API_BASE__ に設定）"
+  value       = aws_apigatewayv2_api.contact.api_endpoint
+}

--- a/provider.tf
+++ b/provider.tf
@@ -7,3 +7,16 @@ provider "aws" {
     }
   }
 }
+
+# CloudFront 用 ACM 証明書は us-east-1 でのみ発行できるため、証明書専用の alias provider を用意する。
+# 配信バケット・API Gateway・Lambda 等は既定 provider（ap-northeast-1）を使う。
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+    }
+  }
+}

--- a/scripts/deploy-pages.sh
+++ b/scripts/deploy-pages.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Abenotech 事業紹介サイトの静的コンテンツ（web/ 配下）を S3 に同期し、
+# CloudFront のキャッシュを無効化する。
+#
+# 前提:
+#   - terraform apply 済み（バケット・CloudFront が存在する）
+#   - AWS 認証済み（例: AWS_PROFILE=master / aws sso login --profile master）
+#   - web/contact.html の __API_BASE__ / __TURNSTILE_SITE_KEY__ を実値へ置換済み
+#
+# 使い方:
+#   AWS_PROFILE=master ./scripts/deploy-pages.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+WEB_DIR="$ROOT_DIR/web"
+
+# バケット名・ディストリビューション ID は terraform output から取得する。
+BUCKET="$(terraform -chdir="$ROOT_DIR" output -raw pages_bucket_name)"
+DIST_ID="$(terraform -chdir="$ROOT_DIR" output -raw pages_cloudfront_distribution_id)"
+
+echo "==> Sync ${WEB_DIR} -> s3://${BUCKET}"
+aws s3 sync "$WEB_DIR" "s3://${BUCKET}" --delete
+
+echo "==> Invalidate CloudFront distribution ${DIST_ID}"
+aws cloudfront create-invalidation \
+  --distribution-id "$DIST_ID" \
+  --paths "/*" \
+  --query 'Invalidation.{Id:Id,Status:Status}' \
+  --output table
+
+echo "==> Done. https://pages.master.makedara.work/"

--- a/static-pages.tf
+++ b/static-pages.tf
@@ -1,0 +1,199 @@
+# ---------------------------------------------------------------------------
+# Abenotech 事業紹介サイトの配信基盤: S3（非公開）+ CloudFront（OAC）+ ACM + Route53。
+# https://pages.master.makedara.work/ を HTTPS 配信する。
+#
+# S3 バケットは非公開のまま CloudFront の OAC（Origin Access Control）経由でのみ読み取り
+# 可能にする。バケットの各種設定・ポリシー作法は ses-inbound.tf に合わせる。
+# 静的コンテンツ（web/ 配下の HTML/CSS/JS）は Terraform では管理せず、
+# scripts/deploy-pages.sh（aws s3 sync + CloudFront invalidation）で配置する。
+# ---------------------------------------------------------------------------
+
+# --- 配信用 S3 バケット（非公開）-------------------------------------------
+
+resource "aws_s3_bucket" "pages" {
+  bucket = local.pages_bucket_name
+}
+
+resource "aws_s3_bucket_ownership_controls" "pages" {
+  bucket = aws_s3_bucket.pages.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "pages" {
+  bucket = aws_s3_bucket.pages.id
+
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "pages" {
+  bucket = aws_s3_bucket.pages.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# --- ACM 証明書（us-east-1・DNS 検証）--------------------------------------
+# CloudFront は us-east-1 の証明書のみ使用できるため aws.us_east_1 provider で発行する。
+
+resource "aws_acm_certificate" "pages" {
+  provider = aws.us_east_1
+
+  domain_name       = local.pages_domain
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# DNS 検証用レコードを Route53 に登録する（証明書は 1 ドメインのため実質 1 レコード）。
+resource "aws_route53_record" "pages_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.pages.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.makedara.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 300
+  records = [each.value.record]
+
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "pages" {
+  provider = aws.us_east_1
+
+  certificate_arn         = aws_acm_certificate.pages.arn
+  validation_record_fqdns = [for r in aws_route53_record.pages_cert_validation : r.fqdn]
+}
+
+# --- CloudFront（OAC 経由で S3 を配信）-------------------------------------
+
+resource "aws_cloudfront_origin_access_control" "pages" {
+  name                              = "pages-oac"
+  description                       = "OAC for ${local.pages_domain}"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "pages" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = local.pages_domain
+  default_root_object = "index.html"
+  aliases             = [local.pages_domain]
+  price_class         = "PriceClass_200" # 日本を含むエッジロケーション。
+
+  origin {
+    domain_name              = aws_s3_bucket.pages.bucket_regional_domain_name
+    origin_id                = "s3-pages"
+    origin_access_control_id = aws_cloudfront_origin_access_control.pages.id
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "s3-pages"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+
+    # AWS マネージドキャッシュポリシー「CachingOptimized」。
+    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+  }
+
+  # 直リンク（存在しないパス）でも Home を返す簡易フォールバック。
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 10
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 10
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.pages.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+}
+
+# --- バケットポリシー（CloudFront の該当 distribution からのみ読み取り許可）-----
+# ses-inbound.tf のポリシー作法（service principal + aws:SourceArn 条件）を踏襲する。
+
+data "aws_iam_policy_document" "pages_bucket" {
+  statement {
+    sid       = "AllowCloudFrontRead"
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.pages.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.pages.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "pages" {
+  bucket = aws_s3_bucket.pages.id
+  policy = data.aws_iam_policy_document.pages_bucket.json
+}
+
+# --- Route53 ALIAS（pages.master.makedara.work → CloudFront）----------------
+# CloudFront の固定ホストゾーン ID は Z2FDTNDATAQYW2（AWS 共通）。
+
+resource "aws_route53_record" "pages_a" {
+  zone_id = data.aws_route53_zone.makedara.zone_id
+  name    = local.pages_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.pages.domain_name
+    zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "pages_aaaa" {
+  zone_id = data.aws_route53_zone.makedara.zone_id
+  name    = local.pages_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.pages.domain_name
+    zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}

--- a/web/contact.html
+++ b/web/contact.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>お問い合わせ — Abenotech（アベノテック）</title>
+<meta name="description" content="アベノテックへのお問い合わせフォーム。">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<!-- Cloudflare Turnstile（Bot 対策）。cf-turnstile 要素を自動描画する。 -->
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+<style>
+  *{box-sizing:border-box;}
+  body{margin:0; background:#F6F7F9;}
+  a{color:#1D4ED8; text-decoration:none;}
+  a:hover{opacity:.72;}
+  input:focus, textarea:focus{outline:none; border-color:#1D4ED8; box-shadow:0 0 0 3px rgba(29,78,216,.12);}
+  ::placeholder{color:#9AA0AC;}
+  button:disabled{opacity:.6; cursor:default;}
+</style>
+</head>
+<body>
+
+<div style="font-family:'IBM Plex Sans JP',system-ui,sans-serif; background:#F6F7F9; color:#0B0E16; min-height:100vh; display:flex; flex-direction:column;">
+
+  <header style="background:rgba(246,247,249,.85); backdrop-filter:blur(10px); border-bottom:1px solid #E9EBEF;">
+    <div style="max-width:1120px; margin:0 auto; padding:16px clamp(20px,5vw,40px); display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:12px 20px;">
+      <a href="index.html" style="display:flex; align-items:baseline; gap:10px; color:inherit;">
+        <span style="font-size:20px; font-weight:700; letter-spacing:-.01em; color:#0F1320;">Abenotech</span>
+        <span style="font-size:12px; color:#8A8F98;">アベノテック</span>
+      </a>
+      <a href="index.html" style="font-size:14px; color:#3B4252;">← ホームに戻る</a>
+    </div>
+  </header>
+
+  <main style="flex:1; max-width:640px; width:100%; margin:0 auto; padding:clamp(48px,8vw,72px) clamp(20px,5vw,40px) clamp(64px,10vw,96px);">
+    <div style="font-family:'IBM Plex Mono',monospace; font-size:12px; letter-spacing:.18em; color:#1D4ED8; margin-bottom:14px;">CONTACT</div>
+    <h1 style="font-size:clamp(30px,6vw,38px); font-weight:700; letter-spacing:-.02em; color:#0B0E16; margin:0 0 44px;">お問い合わせ</h1>
+
+    <!-- 送信完了ビュー（初期は非表示。送信成功で表示に切替） -->
+    <div id="success" style="display:none; background:#fff; border:1px solid #E5E7EB; border-radius:16px; padding:clamp(28px,5vw,48px); text-align:center;">
+      <div style="width:56px; height:56px; border-radius:50%; background:#EAF0FF; color:#1D4ED8; display:flex; align-items:center; justify-content:center; margin:0 auto 22px; font-size:26px;">✓</div>
+      <h2 style="font-size:22px; font-weight:700; color:#0B0E16; margin:0 0 10px;">送信が完了しました</h2>
+      <p style="font-size:15px; line-height:1.8; color:#4B5262; margin:0 0 28px;">お問い合わせありがとうございます。内容を確認のうえ、ご入力いただいたメールアドレスへ折り返しご連絡いたします。</p>
+      <button type="button" id="resetBtn" style="background:#1D4ED8; color:#fff; border:none; padding:13px 26px; border-radius:10px; font-size:15px; font-weight:600; cursor:pointer; font-family:inherit;">続けて問い合わせる</button>
+    </div>
+
+    <!-- 入力フォーム -->
+    <form id="contactForm" novalidate style="background:#fff; border:1px solid #E5E7EB; border-radius:16px; padding:clamp(24px,5vw,40px);">
+      <label style="display:block; margin-bottom:28px;">
+        <span style="display:block; font-size:14px; font-weight:600; color:#0B0E16; margin-bottom:10px;">メールアドレス <span style="color:#1D4ED8;">*</span></span>
+        <input id="email" type="email" required placeholder="you@example.com" autocomplete="email" style="width:100%; padding:14px 16px; border:1px solid #D3D7DF; border-radius:10px; font-size:15px; font-family:inherit; color:#0B0E16; background:#FBFCFD; transition:border-color .15s, box-shadow .15s;">
+      </label>
+      <label style="display:block; margin-bottom:24px;">
+        <span style="display:block; font-size:14px; font-weight:600; color:#0B0E16; margin-bottom:10px;">お問い合わせ内容 <span style="color:#1D4ED8;">*</span></span>
+        <textarea id="message" required rows="7" placeholder="ご相談内容をご記入ください。" style="width:100%; padding:14px 16px; border:1px solid #D3D7DF; border-radius:10px; font-size:15px; font-family:inherit; line-height:1.8; color:#0B0E16; background:#FBFCFD; resize:vertical; transition:border-color .15s, box-shadow .15s;"></textarea>
+      </label>
+
+      <!-- Turnstile ウィジェット。data-sitekey はデプロイ時に実 site key へ置換する。 -->
+      <div style="margin-bottom:24px; min-height:65px;">
+        <div class="cf-turnstile" data-sitekey="__TURNSTILE_SITE_KEY__"></div>
+      </div>
+
+      <div style="display:flex; align-items:center; gap:16px; flex-wrap:wrap;">
+        <button type="submit" id="submitBtn" style="display:inline-flex; align-items:center; gap:8px; background:#1D4ED8; color:#fff; border:none; padding:15px 32px; border-radius:10px; font-size:15px; font-weight:600; cursor:pointer; font-family:inherit;">送信する →</button>
+        <span style="font-size:13px; color:#8A8F98;">送信をもって<a href="privacy.html">プライバシーポリシー</a>に同意したものとみなします。</span>
+      </div>
+      <p id="formError" style="display:none; margin-top:16px; font-size:13px; color:#C9483A; font-weight:500;">送信に失敗しました。時間をおいて、もう一度お試しください。</p>
+    </form>
+  </main>
+
+  <footer style="background:#fff; border-top:1px solid #E9EBEF;">
+    <div style="max-width:1120px; margin:0 auto; padding:32px clamp(20px,5vw,40px); display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:16px;">
+      <span style="font-weight:700; color:#0B0E16;">Abenotech</span>
+      <div style="display:flex; gap:24px; align-items:center; font-size:13px; color:#6B7280;">
+        <a href="privacy.html" style="color:#6B7280;">プライバシーポリシー</a>
+        <span>© 2026 Abenotech</span>
+      </div>
+    </div>
+  </footer>
+
+</div>
+
+<script>
+  // ▼▼ デプロイ時に実値へ差し替える設定（静的 HTML のためプレースホルダーを置換）▼▼
+  // API_BASE: 問い合わせ API のエンドポイント（terraform output contact_api_endpoint）
+  //   例: https://xxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com
+  // Turnstile の Site Key は上の <div class="cf-turnstile" data-sitekey="..."> に埋め込む。
+  var API_BASE = '__API_BASE__';
+  // ▲▲ ここまで差し替え ▲▲
+
+  var form = document.getElementById('contactForm');
+  var success = document.getElementById('success');
+  var submitBtn = document.getElementById('submitBtn');
+  var resetBtn = document.getElementById('resetBtn');
+  var formError = document.getElementById('formError');
+  var emailEl = document.getElementById('email');
+  var messageEl = document.getElementById('message');
+
+  function emailOk(v){ return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v); }
+
+  function showError(msg){
+    formError.textContent = msg;
+    formError.style.display = 'block';
+  }
+  function clearError(){ formError.style.display = 'none'; }
+
+  // Turnstile のトークンを取得する。widget 未描画・未通過なら空文字。
+  function turnstileToken(){
+    return (window.turnstile && typeof window.turnstile.getResponse === 'function')
+      ? (window.turnstile.getResponse() || '')
+      : '';
+  }
+  function resetTurnstile(){
+    if(window.turnstile && typeof window.turnstile.reset === 'function'){
+      window.turnstile.reset();
+    }
+  }
+
+  form.addEventListener('submit', function(e){
+    e.preventDefault();
+    clearError();
+
+    var email = emailEl.value.trim();
+    var message = messageEl.value.trim();
+
+    if(!emailOk(email)){
+      showError('正しいメールアドレスをご入力ください。');
+      emailEl.focus();
+      return;
+    }
+    if(message.length < 10){
+      showError('お問い合わせ内容をご入力ください（10文字以上）。');
+      messageEl.focus();
+      return;
+    }
+
+    var token = turnstileToken();
+    if(!token){
+      showError('「私は人間です」の確認を完了してから送信してください。');
+      return;
+    }
+
+    submitBtn.disabled = true;
+    fetch(API_BASE + '/contact', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: email, message: message, turnstileToken: token })
+    })
+    .then(function(res){
+      if(!res.ok){ throw new Error('request failed: ' + res.status); }
+      form.style.display = 'none';
+      success.style.display = 'block';
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    })
+    .catch(function(){
+      showError('送信に失敗しました。時間をおいて、もう一度お試しください。');
+      submitBtn.disabled = false;
+      resetTurnstile();
+    });
+  });
+
+  // 「続けて問い合わせる」でフォームへ戻す。
+  resetBtn.addEventListener('click', function(){
+    emailEl.value = '';
+    messageEl.value = '';
+    clearError();
+    submitBtn.disabled = false;
+    resetTurnstile();
+    success.style.display = 'none';
+    form.style.display = 'block';
+  });
+</script>
+
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Abenotech（アベノテック）— モバイルとクラウドで、アイデアを、動かす。</title>
+<meta name="description" content="アベノテックは、スマートフォンアプリの企画・開発から、AWSインフラの構築、Web開発までを一貫して支援する個人事業です。">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  *{box-sizing:border-box;}
+  body{margin:0; background:#F6F7F9;}
+  a{color:#1D4ED8; text-decoration:none;}
+  a:hover{opacity:.72;}
+  @keyframes pulseDot{0%,100%{opacity:.3; transform:scale(1);}50%{opacity:1; transform:scale(1.25);}}
+</style>
+</head>
+<body>
+
+<div style="font-family:'IBM Plex Sans JP',system-ui,sans-serif; background:#F6F7F9; color:#0B0E16; min-height:100vh;">
+
+  <header style="position:sticky; top:0; z-index:20; background:rgba(246,247,249,.85); backdrop-filter:blur(10px); border-bottom:1px solid #E9EBEF;">
+    <div style="max-width:1120px; margin:0 auto; padding:16px clamp(20px,5vw,40px); display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:12px 20px;">
+      <a href="index.html" style="display:flex; align-items:baseline; gap:10px; color:inherit;">
+        <span style="font-size:20px; font-weight:700; letter-spacing:-.01em; color:#0F1320;">Abenotech</span>
+        <span style="font-size:12px; color:#8A8F98;">アベノテック</span>
+      </a>
+      <nav style="display:flex; align-items:center; gap:clamp(16px,3vw,30px); font-size:14px;">
+        <a href="#services" style="color:#3B4252;">事業内容</a>
+        <a href="#works" style="color:#3B4252;">実績</a>
+        <a href="contact.html" style="display:inline-flex; align-items:center; background:#1D4ED8; color:#fff; padding:9px 18px; border-radius:8px; font-weight:600;">お問い合わせ</a>
+      </nav>
+    </div>
+  </header>
+
+  <section style="max-width:1120px; margin:0 auto; padding:clamp(48px,8vw,88px) clamp(20px,5vw,40px) clamp(48px,7vw,76px); display:grid; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); gap:clamp(32px,5vw,48px); align-items:center;">
+    <div>
+      <h1 style="font-size:clamp(32px,6.2vw,54px); line-height:1.2; font-weight:700; letter-spacing:-.02em; color:#0B0E16; margin:0 0 24px;">モバイルとクラウドで、<br>アイデアを、動かす。</h1>
+      <p style="font-size:17px; line-height:1.9; color:#4B5262; max-width:520px; margin:0 0 36px;">アベノテックは、スマートフォンアプリの企画・開発から、AWSインフラの構築、Web開発までを一貫して支援する個人事業です。</p>
+      <div style="display:flex; gap:14px; flex-wrap:wrap;">
+        <a href="contact.html" style="display:inline-flex; align-items:center; gap:8px; background:#1D4ED8; color:#fff; padding:15px 28px; border-radius:10px; font-size:15px; font-weight:600;">お問い合わせ →</a>
+        <a href="#services" style="display:inline-flex; align-items:center; padding:15px 24px; border-radius:10px; border:1px solid #D3D7DF; color:#0F1320; font-size:15px; font-weight:500;">事業内容を見る</a>
+      </div>
+    </div>
+    <div style="position:relative; height:clamp(280px,42vw,400px); min-height:280px; border-radius:16px; overflow:hidden; border:1px solid #E5E7EB; background:repeating-linear-gradient(135deg,#EEF1F6 0 14px,#E6EAF1 14px 28px);">
+      <div style="position:absolute; inset:0; display:flex; align-items:center; justify-content:center;">
+        <span style="font-family:'IBM Plex Mono',monospace; font-size:12px; color:#9AA0AC; background:#F6F7F9; padding:6px 12px; border-radius:6px;">product / UI shot</span>
+      </div>
+      <div style="position:absolute; top:24px; right:24px; width:12px; height:12px; border-radius:50%; background:#1D4ED8; animation:pulseDot 2s ease-in-out infinite;"></div>
+    </div>
+  </section>
+
+  <section id="services" style="background:#fff; border-top:1px solid #E9EBEF; border-bottom:1px solid #E9EBEF;">
+    <div style="max-width:1120px; margin:0 auto; padding:clamp(48px,7vw,72px) clamp(20px,5vw,40px);">
+      <div style="display:flex; align-items:baseline; justify-content:space-between; margin-bottom:44px; gap:24px;">
+        <div>
+          <div style="font-family:'IBM Plex Mono',monospace; font-size:12px; letter-spacing:.18em; color:#1D4ED8; margin-bottom:12px;">SERVICES</div>
+          <h2 style="font-size:34px; font-weight:700; color:#0B0E16; margin:0;">事業内容</h2>
+        </div>
+      </div>
+      <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:22px;">
+        <div style="border:1px solid #E5E7EB; border-radius:14px; padding:32px; background:#FBFCFD;">
+          <div style="font-family:'IBM Plex Mono',monospace; font-size:13px; color:#1D4ED8; margin-bottom:24px;">01</div>
+          <h3 style="font-size:21px; font-weight:700; color:#0B0E16; margin:0 0 6px;">アプリ開発</h3>
+          <div style="font-family:'IBM Plex Mono',monospace; font-size:11px; letter-spacing:.06em; color:#9AA0AC; margin-bottom:16px;">MOBILE APP DEV</div>
+          <p style="font-size:14px; line-height:1.85; color:#4B5262; margin:0;">Android・iPhoneアプリの企画・開発・運営。ネイティブアプリを一貫して手掛けます。</p>
+        </div>
+        <div style="border:1px solid #E5E7EB; border-radius:14px; padding:32px; background:#FBFCFD;">
+          <div style="font-family:'IBM Plex Mono',monospace; font-size:13px; color:#1D4ED8; margin-bottom:24px;">02</div>
+          <h3 style="font-size:21px; font-weight:700; color:#0B0E16; margin:0 0 6px;">AWSインフラ構築</h3>
+          <div style="font-family:'IBM Plex Mono',monospace; font-size:11px; letter-spacing:.06em; color:#9AA0AC; margin-bottom:16px;">AWS INFRASTRUCTURE</div>
+          <p style="font-size:14px; line-height:1.85; color:#4B5262; margin:0;">AWS上でのインフラ構築を支援。スケーラブルで安定した基盤を設計します。</p>
+        </div>
+        <div style="border:1px solid #E5E7EB; border-radius:14px; padding:32px; background:#FBFCFD;">
+          <div style="font-family:'IBM Plex Mono',monospace; font-size:13px; color:#1D4ED8; margin-bottom:24px;">03</div>
+          <h3 style="font-size:21px; font-weight:700; color:#0B0E16; margin:0 0 6px;">Web開発</h3>
+          <div style="font-family:'IBM Plex Mono',monospace; font-size:11px; letter-spacing:.06em; color:#9AA0AC; margin-bottom:16px;">WEB DEVELOPMENT</div>
+          <p style="font-size:14px; line-height:1.85; color:#4B5262; margin:0;">Webアプリケーションの開発支援。モダンな技術で使いやすいプロダクトを。</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="works" style="max-width:1120px; margin:0 auto; padding:clamp(56px,8vw,84px) clamp(20px,5vw,40px); text-align:center;">
+    <div style="font-family:'IBM Plex Mono',monospace; font-size:12px; letter-spacing:.18em; color:#1D4ED8; margin-bottom:14px;">WORKS</div>
+    <h2 style="font-size:32px; font-weight:700; color:#0B0E16; margin:0 0 24px;">実績</h2>
+    <div style="display:inline-flex; align-items:center; gap:12px; padding:18px 34px; border:1px dashed #C4C9D2; border-radius:12px; background:#fff;">
+      <span style="width:8px; height:8px; border-radius:50%; background:#1D4ED8; animation:pulseDot 1.5s infinite;"></span>
+      <span style="font-size:18px; font-weight:600; color:#0B0E16;">Coming soon</span>
+    </div>
+    <p style="font-size:14px; color:#6B7280; margin:20px 0 0;">実績は現在準備中です。近日公開予定。</p>
+  </section>
+
+  <section style="max-width:1120px; margin:0 auto; padding:0 clamp(20px,5vw,40px) clamp(56px,8vw,84px);">
+    <div style="background:#0E2A6B; border-radius:18px; padding:clamp(32px,5vw,56px); display:flex; align-items:center; justify-content:space-between; gap:24px; flex-wrap:wrap;">
+      <div>
+        <div style="font-family:'IBM Plex Mono',monospace; font-size:12px; letter-spacing:.18em; color:#9DB4FF; margin-bottom:12px;">CONTACT</div>
+        <h2 style="font-size:30px; font-weight:700; color:#fff; margin:0;">お問い合わせ</h2>
+      </div>
+      <a href="contact.html" style="background:#fff; color:#0E2A6B; padding:16px 30px; border-radius:10px; font-weight:600; font-size:15px; white-space:nowrap;">問い合わせフォームへ →</a>
+    </div>
+  </section>
+
+  <footer style="background:#fff; border-top:1px solid #E9EBEF;">
+    <div style="max-width:1120px; margin:0 auto; padding:32px clamp(20px,5vw,40px); display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:16px;">
+      <span style="font-weight:700; color:#0B0E16;">Abenotech</span>
+      <div style="display:flex; gap:24px; align-items:center; font-size:13px; color:#6B7280;">
+        <a href="privacy.html" style="color:#6B7280;">プライバシーポリシー</a>
+        <a href="contact.html" style="color:#6B7280;">お問い合わせ</a>
+        <span>© 2026 Abenotech</span>
+      </div>
+    </div>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>プライバシーポリシー — Abenotech（アベノテック）</title>
+<meta name="description" content="アベノテックの個人情報の取り扱い方針（プライバシーポリシー）。">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  *{box-sizing:border-box;}
+  body{margin:0; background:#F6F7F9;}
+  a{color:#1D4ED8; text-decoration:none;}
+  a:hover{opacity:.72;}
+</style>
+</head>
+<body>
+
+<div style="font-family:'IBM Plex Sans JP',system-ui,sans-serif; background:#F6F7F9; color:#0B0E16; min-height:100vh; display:flex; flex-direction:column;">
+
+  <header style="background:rgba(246,247,249,.85); backdrop-filter:blur(10px); border-bottom:1px solid #E9EBEF;">
+    <div style="max-width:1120px; margin:0 auto; padding:16px clamp(20px,5vw,40px); display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:12px 20px;">
+      <a href="index.html" style="display:flex; align-items:baseline; gap:10px; color:inherit;">
+        <span style="font-size:20px; font-weight:700; letter-spacing:-.01em; color:#0F1320;">Abenotech</span>
+        <span style="font-size:12px; color:#8A8F98;">アベノテック</span>
+      </a>
+      <a href="index.html" style="font-size:14px; color:#3B4252;">← ホームに戻る</a>
+    </div>
+  </header>
+
+  <main style="flex:1; max-width:760px; width:100%; margin:0 auto; padding:clamp(48px,8vw,72px) clamp(20px,5vw,40px) clamp(64px,10vw,96px);">
+    <div style="font-family:'IBM Plex Mono',monospace; font-size:12px; letter-spacing:.18em; color:#1D4ED8; margin-bottom:14px;">PRIVACY POLICY</div>
+    <h1 style="font-size:clamp(30px,6vw,38px); font-weight:700; letter-spacing:-.02em; color:#0B0E16; margin:0 0 14px;">プライバシーポリシー</h1>
+    <p style="font-size:15px; line-height:1.9; color:#4B5262; margin:0 0 8px;">アベノテック（以下「当事業」といいます）は、お客様の個人情報の保護を重要な責務と考え、以下の方針に基づき個人情報を適切に取り扱います。</p>
+    <p style="font-family:'IBM Plex Mono',monospace; font-size:12px; color:#9AA0AC; margin:0 0 48px;">最終改定日：2026年7月8日</p>
+
+    <div style="background:#fff; border:1px solid #E5E7EB; border-radius:16px; padding:8px clamp(20px,5vw,40px);">
+
+      <section style="padding:32px 0; border-bottom:1px solid #EEF0F3;">
+        <h2 style="display:flex; align-items:baseline; gap:14px; font-size:19px; font-weight:700; color:#0B0E16; margin:0 0 14px;"><span style="font-family:'IBM Plex Mono',monospace; font-size:13px; color:#1D4ED8;">01</span>事業者情報</h2>
+        <p style="font-size:15px; line-height:1.9; color:#4B5262; margin:0;">名称：アベノテック（Abenotech）<br>事業形態：個人事業主<br>事業内容：スマートフォンアプリの企画・開発・運営、AWSインフラの構築支援、Webアプリの開発支援</p>
+      </section>
+
+      <section style="padding:32px 0; border-bottom:1px solid #EEF0F3;">
+        <h2 style="display:flex; align-items:baseline; gap:14px; font-size:19px; font-weight:700; color:#0B0E16; margin:0 0 14px;"><span style="font-family:'IBM Plex Mono',monospace; font-size:13px; color:#1D4ED8;">02</span>取得する個人情報</h2>
+        <p style="font-size:15px; line-height:1.9; color:#4B5262; margin:0;">当事業は、お問い合わせフォームを通じて、メールアドレスおよびお問い合わせ内容に含まれる情報を取得します。取得はお客様の任意によるものです。</p>
+      </section>
+
+      <section style="padding:32px 0; border-bottom:1px solid #EEF0F3;">
+        <h2 style="display:flex; align-items:baseline; gap:14px; font-size:19px; font-weight:700; color:#0B0E16; margin:0 0 14px;"><span style="font-family:'IBM Plex Mono',monospace; font-size:13px; color:#1D4ED8;">03</span>利用目的</h2>
+        <p style="font-size:15px; line-height:1.9; color:#4B5262; margin:0;">取得した個人情報は、次の目的の範囲内で利用します。<br>・お問い合わせへの回答およびご連絡のため<br>・ご依頼いただいた業務の遂行およびご案内のため<br>・お客様との連絡・調整のため</p>
+      </section>
+
+      <section style="padding:32px 0; border-bottom:1px solid #EEF0F3;">
+        <h2 style="display:flex; align-items:baseline; gap:14px; font-size:19px; font-weight:700; color:#0B0E16; margin:0 0 14px;"><span style="font-family:'IBM Plex Mono',monospace; font-size:13px; color:#1D4ED8;">04</span>第三者提供</h2>
+        <p style="font-size:15px; line-height:1.9; color:#4B5262; margin:0;">当事業は、法令に基づく場合を除き、あらかじめお客様の同意を得ることなく、取得した個人情報を第三者に提供することはありません。</p>
+      </section>
+
+      <section style="padding:32px 0; border-bottom:1px solid #EEF0F3;">
+        <h2 style="display:flex; align-items:baseline; gap:14px; font-size:19px; font-weight:700; color:#0B0E16; margin:0 0 14px;"><span style="font-family:'IBM Plex Mono',monospace; font-size:13px; color:#1D4ED8;">05</span>安全管理措置</h2>
+        <p style="font-size:15px; line-height:1.9; color:#4B5262; margin:0;">当事業は、取得した個人情報の漏えい、滅失またはき損の防止その他の安全管理のために、必要かつ適切な措置を講じます。</p>
+      </section>
+
+      <section style="padding:32px 0; border-bottom:1px solid #EEF0F3;">
+        <h2 style="display:flex; align-items:baseline; gap:14px; font-size:19px; font-weight:700; color:#0B0E16; margin:0 0 14px;"><span style="font-family:'IBM Plex Mono',monospace; font-size:13px; color:#1D4ED8;">06</span>開示・訂正・削除</h2>
+        <p style="font-size:15px; line-height:1.9; color:#4B5262; margin:0;">お客様がご自身の個人情報の開示・訂正・利用停止・削除を希望される場合は、下記のお問い合わせ窓口までご連絡ください。ご本人であることを確認のうえ、法令に従い速やかに対応します。</p>
+      </section>
+
+      <section style="padding:32px 0; border-bottom:1px solid #EEF0F3;">
+        <h2 style="display:flex; align-items:baseline; gap:14px; font-size:19px; font-weight:700; color:#0B0E16; margin:0 0 14px;"><span style="font-family:'IBM Plex Mono',monospace; font-size:13px; color:#1D4ED8;">07</span>改定について</h2>
+        <p style="font-size:15px; line-height:1.9; color:#4B5262; margin:0;">当事業は、法令の変更や事業内容の変更に応じて、本ポリシーを予告なく改定することがあります。改定後の内容は本ページに掲載した時点から効力を生じるものとします。</p>
+      </section>
+
+      <section style="padding:32px 0;">
+        <h2 style="display:flex; align-items:baseline; gap:14px; font-size:19px; font-weight:700; color:#0B0E16; margin:0 0 14px;"><span style="font-family:'IBM Plex Mono',monospace; font-size:13px; color:#1D4ED8;">08</span>お問い合わせ窓口</h2>
+        <p style="font-size:15px; line-height:1.9; color:#4B5262; margin:0;">本ポリシーおよび個人情報の取り扱いに関するお問い合わせは、<a href="contact.html">お問い合わせフォーム</a>よりご連絡ください。</p>
+      </section>
+
+    </div>
+  </main>
+
+  <footer style="background:#fff; border-top:1px solid #E9EBEF;">
+    <div style="max-width:1120px; margin:0 auto; padding:32px clamp(20px,5vw,40px); display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:16px;">
+      <span style="font-weight:700; color:#0B0E16;">Abenotech</span>
+      <div style="display:flex; gap:24px; align-items:center; font-size:13px; color:#6B7280;">
+        <a href="privacy.html" style="color:#6B7280;">プライバシーポリシー</a>
+        <a href="contact.html" style="color:#6B7280;">お問い合わせ</a>
+        <span>© 2026 Abenotech</span>
+      </div>
+    </div>
+  </footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 概要

アベノテック（Abenotech）の事業紹介サイトを `https://pages.master.makedara.work/` に構築する。静的3ページ（Home / Contact / Privacy）を CloudFront + S3(OAC) で HTTPS 配信し、問い合わせフォームは Cloudflare Turnstile で Bot を弾いたうえで API Gateway + Lambda が Turnstile 検証 → SES メール通知する。通知先を `contact@master.makedara.work` にすることで既存の SES 受信転送・SMTP 返信構成をそのまま再利用する。

## 変更内容

- **配信インフラ**（`static-pages.tf` / `provider.tf`）: 非公開 S3 + CloudFront(OAC) + ACM(us-east-1・DNS検証) + Route53 ALIAS。us-east-1 用 alias provider を追加。バケット作法・ポリシーは `ses-inbound.tf` を踏襲
- **問い合わせ API**（`contact-api.tf` / `lambda/contact/index.mjs`）: API Gateway HTTP API + Lambda（依存追加なしの自己完結 ESM）。Turnstile siteverify → SESv2 で通知送信（Reply-To に問い合わせ者）。Turnstile シークレットは SSM SecureString（placeholder、実値は手動投入）
- **静的3ページ**（`web/`）: design_handoff のインラインスタイルを忠実再現。Contact のみ Turnstile ウィジェット + fetch 送信 + 完了ビュー切替を実装（site key / API_BASE はプレースホルダー）
- **デプロイ**（`scripts/deploy-pages.sh`）: `aws s3 sync` + CloudFront invalidation
- **ドキュメント**（`README.md`）: Turnstile 作成・SSM 投入・HTML 埋め込み・デプロイの手動手順を追記
- `locals.tf` / `outputs.tf`: pages 用の値・出力を追加

## 設計

- 対応 plan: `.claude/plans/issue-48-abenotech-pages-site.md`

## 動作確認

- `terraform fmt`（本PRの対象ファイルは整形済み）／`terraform validate` → Success
- `node --check lambda/contact/index.mjs` / `bash -n scripts/deploy-pages.sh` → OK
- `terraform plan` / `apply` はユーザーが実行（本リポジトリ方針）。apply 後の疎通確認手順は README「重要: Abenotech 事業紹介サイト…」節に記載:
  - HTTPS 表示・3ページ相互遷移・レスポンシブ
  - Turnstile 未通過は送信ブロック、通過送信で運営 Gmail に通知 → Reply-To 返信が送信者に届く

Close #48
