### PR TITLE
Abenotech 事業紹介サイトのドメインを master.makedara.work に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ NS 委任・SES サンドボックス解除・Gmail 設定は Terraform 管理�
    - `contact@master.makedara.work` にテスト送信 → Gmail に転送されること
    - Gmail から返信 → 元送信者に `contact@` 名義で届くことを確認
 
-### 重要: Abenotech 事業紹介サイト（pages.master.makedara.work）について
+### 重要: Abenotech 事業紹介サイト（master.makedara.work）について
 
-`https://pages.master.makedara.work/` で事業紹介サイト（静的 3 ページ）を配信し、問い合わせ
+`https://master.makedara.work/` で事業紹介サイト（静的 3 ページ）を配信し、問い合わせ
 フォームは Cloudflare Turnstile で Bot を弾いたうえで SES メール通知します。配信は
 CloudFront + S3（OAC）、問い合わせ API は API Gateway + Lambda 構成です。
 静的コンテンツ（`web/` 配下）は Terraform では管理せず、`scripts/deploy-pages.sh` で配置します。
@@ -142,8 +142,10 @@ Turnstile ウィジェットの作成・シークレット投入・HTML への�
 #### 実行手順
 
 1. **Cloudflare Turnstile ウィジェットを作成**
-   - Cloudflare ダッシュボード → Turnstile で `pages.master.makedara.work` 用ウィジェットを追加
+   - Cloudflare ダッシュボード → Turnstile で `master.makedara.work` 用ウィジェットを追加
    - 払い出された **Site Key**（公開値）と **Secret Key**（機密値）を控える
+   - 既存ウィジェット（旧 `pages.master.makedara.work`）を流用する場合は、許可ホスト名に
+     `master.makedara.work` を追加する。Site Key を変えないなら手順3・4 の差し替えは不要
 
 2. **terraform apply（ユーザーが実行）**
    ```bash
@@ -177,7 +179,7 @@ Turnstile ウィジェットの作成・シークレット投入・HTML への�
    - `web/` を配信バケットへ同期し、CloudFront キャッシュを無効化します
 
 6. **疎通確認**
-   - `https://pages.master.makedara.work/` が HTTPS で表示され、3 ページを相互遷移できること
+   - `https://master.makedara.work/` が HTTPS で表示され、3 ページを相互遷移できること
    - 問い合わせフォームで Turnstile を通過し送信 → `contact@master.makedara.work` に通知が届き、
      既存の転送で運営 Gmail に届くこと。その返信が送信者に届くこと（Reply-To）
 

--- a/contact-api.tf
+++ b/contact-api.tf
@@ -1,6 +1,6 @@
 # ---------------------------------------------------------------------------
 # 問い合わせ API: API Gateway HTTP API + Lambda。
-# サイト（pages.master.makedara.work）の問い合わせフォームから POST /contact を受け、
+# サイト（master.makedara.work）の問い合わせフォームから POST /contact を受け、
 # Cloudflare Turnstile 検証後に SES で運営宛通知メールを送信する。
 #
 # Lambda は lambda/contact/index.mjs（依存追加なしの自己完結 ESM。lambda/ses-forward と同方針）。
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_log_group" "contact" {
 
 resource "aws_ssm_parameter" "turnstile_secret" {
   name        = "/master/turnstile/secret-key"
-  description = "Cloudflare Turnstile secret key for pages.master.makedara.work. Set manually via AWS CLI."
+  description = "Cloudflare Turnstile secret key for master.makedara.work. Set manually via AWS CLI."
   type        = "SecureString"
   value       = "PLACEHOLDER_REPLACE_MANUALLY"
 

--- a/locals.tf
+++ b/locals.tf
@@ -8,8 +8,8 @@ locals {
   ses_inbound_bucket_uuid = "03da39ab-5aab-44cd-afef-43666e52e62d"
   ses_inbound_bucket_name = "master-ses-inbound-${local.ses_inbound_bucket_uuid}"
 
-  # Abenotech 事業紹介サイト（pages.master.makedara.work）。
-  pages_domain = "pages.${local.makedara_domain}"
+  # Abenotech 事業紹介サイト（master.makedara.work）。
+  pages_domain = local.makedara_domain
 
   # 配信バケット名の UUID を一元管理（グローバル一意にするため固定 UUID を付与）。
   pages_bucket_uuid = "fd50acc4-0697-427a-a30f-3a03e12a4bb6"

--- a/scripts/deploy-pages.sh
+++ b/scripts/deploy-pages.sh
@@ -29,4 +29,4 @@ aws cloudfront create-invalidation \
   --query 'Invalidation.{Id:Id,Status:Status}' \
   --output table
 
-echo "==> Done. https://pages.master.makedara.work/"
+echo "==> Done. https://master.makedara.work/"

--- a/static-pages.tf
+++ b/static-pages.tf
@@ -1,6 +1,6 @@
 # ---------------------------------------------------------------------------
 # Abenotech 事業紹介サイトの配信基盤: S3（非公開）+ CloudFront（OAC）+ ACM + Route53。
-# https://pages.master.makedara.work/ を HTTPS 配信する。
+# https://master.makedara.work/ を HTTPS 配信する。
 #
 # S3 バケットは非公開のまま CloudFront の OAC（Origin Access Control）経由でのみ読み取り
 # 可能にする。バケットの各種設定・ポリシー作法は ses-inbound.tf に合わせる。
@@ -171,7 +171,7 @@ resource "aws_s3_bucket_policy" "pages" {
   policy = data.aws_iam_policy_document.pages_bucket.json
 }
 
-# --- Route53 ALIAS（pages.master.makedara.work → CloudFront）----------------
+# --- Route53 ALIAS（master.makedara.work → CloudFront）----------------
 # CloudFront の固定ホストゾーン ID は Z2FDTNDATAQYW2（AWS 共通）。
 
 resource "aws_route53_record" "pages_a" {


### PR DESCRIPTION
## 概要

Abenotech 事業紹介サイトの配信ドメインを `pages.master.makedara.work` からサブドメインなしの `master.makedara.work` に変更する。ドメイン文字列は `locals.tf` の `pages_domain` に集約されているため、この1箇所を変更すれば ACM 証明書・CloudFront alias・Route53 A/AAAA・CORS がすべて追従する。S3 バケット名（`pages-{uuid}`）は変更しない。

## 変更内容

- `locals.tf`: `pages_domain` を `pages.${makedara_domain}` → `makedara_domain`（= `master.makedara.work`）に変更
- `static-pages.tf` / `contact-api.tf`: ドメインを含むコメント・description を新ドメインに更新（リソース本体は local 参照のため変更不要）
- `scripts/deploy-pages.sh`: 完了メッセージの URL を更新
- `README.md`: 手順・疎通確認の記載を更新。Turnstile は既存ウィジェットの許可ホスト名に `master.makedara.work` を追加する手動対応を注記

`terraform apply` 時、旧 `pages.master.makedara.work` の Route53 A/AAAA レコードと ACM 証明書は新ドメインのものへ置換される（`create_before_destroy` により無停止）。

## 設計

- 対応 plan: `.claude/plans/issue-50-abenotech-master-makedara-work.md`

## 動作確認

- `terraform validate`: Success（設定は valid）
- `terraform fmt`: 編集した3ファイルは整形済み（差分は対象外の既存 `backend.tf` のみ）
- `terraform plan` / `apply` はユーザーが実施。plan で ACM 再作成・CloudFront alias 更新・Route53 A/AAAA の置換・S3 バケット無変更を確認予定
- apply 後、`https://master.makedara.work/` の HTTPS 表示と問い合わせフォーム送信を疎通確認

> 注意: Cloudflare Turnstile ウィジェット（Terraform 管理外）は現行 `pages.master.makedara.work` に紐づくため、新ドメインで検証を通すには許可ホスト名の追加が必要です。

Close #50