### PR TITLE
makedara.work でもサイトを配信し、master.makedara.work を Route 53 内で NS 委譲する

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,15 @@ NS 委任・SES サンドボックス解除・Gmail 設定は Terraform 管理�
 #### 実行手順
 
 1. **Route53 ホストゾーンを手動作成**
-   - マスターアカウントのコンソールで `master.makedara.work` の public hosted zone を作成
-   - 払い出された Zone ID を `terraform.tfvars` の `master_makedara_zone_id` に設定
+   - マスターアカウントのコンソールで `makedara.work`（apex）と `master.makedara.work` の
+     public hosted zone をそれぞれ作成
+   - 払い出された Zone ID を `terraform.tfvars` の `makedara_zone_id` /
+     `master_makedara_zone_id` に設定
 
-2. **親ドメインへ NS 委任**
-   - `makedara.work` を管理する DNS（レジストラ or 親ゾーン）に、手順1で払い出された
-     4 本の NS を持つ `master` サブドメインの NS レコードを追加して委任する
+2. **レジストラから apex へ NS 委任**
+   - お名前ドットコムのネームサーバー設定を、`makedara.work` ゾーンの NS 4 本に変更する
+   - `master.makedara.work` への委任は Terraform が `makedara.work` ゾーン内に NS レコード
+     （`aws_route53_record.master_delegation`）として作成するため、レジストラ側の設定は不要
 
 3. **terraform apply（ユーザーが実行）**
    ```bash
@@ -131,9 +134,10 @@ NS 委任・SES サンドボックス解除・Gmail 設定は Terraform 管理�
    - `contact@master.makedara.work` にテスト送信 → Gmail に転送されること
    - Gmail から返信 → 元送信者に `contact@` 名義で届くことを確認
 
-### 重要: Abenotech 事業紹介サイト（master.makedara.work）について
+### 重要: Abenotech 事業紹介サイト（makedara.work / master.makedara.work）について
 
-`https://master.makedara.work/` で事業紹介サイト（静的 3 ページ）を配信し、問い合わせ
+`https://makedara.work/` と `https://master.makedara.work/` の両方（同一 CloudFront
+distribution・同一コンテンツ）で事業紹介サイト（静的 3 ページ）を配信し、問い合わせ
 フォームは Cloudflare Turnstile で Bot を弾いたうえで SES メール通知します。配信は
 CloudFront + S3（OAC）、問い合わせ API は API Gateway + Lambda 構成です。
 静的コンテンツ（`web/` 配下）は Terraform では管理せず、`scripts/deploy-pages.sh` で配置します。
@@ -146,6 +150,8 @@ Turnstile ウィジェットの作成・シークレット投入・HTML への�
    - 払い出された **Site Key**（公開値）と **Secret Key**（機密値）を控える
    - 既存ウィジェット（旧 `pages.master.makedara.work`）を流用する場合は、許可ホスト名に
      `master.makedara.work` を追加する。Site Key を変えないなら手順3・4 の差し替えは不要
+   - サイトは 2 ホスト名で配信するため、許可ホスト名に **`makedara.work` も必ず追加**する
+     （未追加だと apex 経由のフォーム送信で Turnstile が失敗する）
 
 2. **terraform apply（ユーザーが実行）**
    ```bash
@@ -179,9 +185,10 @@ Turnstile ウィジェットの作成・シークレット投入・HTML への�
    - `web/` を配信バケットへ同期し、CloudFront キャッシュを無効化します
 
 6. **疎通確認**
-   - `https://master.makedara.work/` が HTTPS で表示され、3 ページを相互遷移できること
-   - 問い合わせフォームで Turnstile を通過し送信 → `contact@master.makedara.work` に通知が届き、
-     既存の転送で運営 Gmail に届くこと。その返信が送信者に届くこと（Reply-To）
+   - `https://master.makedara.work/` と `https://makedara.work/` の両方が HTTPS で表示され、
+     3 ページを相互遷移できること
+   - 両ホスト名の問い合わせフォームで Turnstile を通過し送信 → `contact@master.makedara.work`
+     に通知が届き、既存の転送で運営 Gmail に届くこと。その返信が送信者に届くこと（Reply-To）
 
 > 補足: 問い合わせ通知の宛先は検証済みの `contact@master.makedara.work` のため、
 > SES サンドボックスのままでも通知メールは送信されます（既存の受信転送に相乗り）。

--- a/backend.tf
+++ b/backend.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "terraform-state-919172dc-8283-4326-83de-fdfadef3bb78"
-    key            = "terraform.tfstate"
-    region         = "ap-northeast-1"
-    use_lockfile   = true
-    encrypt        = true
+    bucket       = "terraform-state-919172dc-8283-4326-83de-fdfadef3bb78"
+    key          = "terraform.tfstate"
+    region       = "ap-northeast-1"
+    use_lockfile = true
+    encrypt      = true
   }
 }

--- a/contact-api.tf
+++ b/contact-api.tf
@@ -1,6 +1,6 @@
 # ---------------------------------------------------------------------------
 # 問い合わせ API: API Gateway HTTP API + Lambda。
-# サイト（master.makedara.work）の問い合わせフォームから POST /contact を受け、
+# サイト（master.makedara.work / makedara.work）の問い合わせフォームから POST /contact を受け、
 # Cloudflare Turnstile 検証後に SES で運営宛通知メールを送信する。
 #
 # Lambda は lambda/contact/index.mjs（依存追加なしの自己完結 ESM。lambda/ses-forward と同方針）。
@@ -111,7 +111,8 @@ resource "aws_lambda_function" "contact" {
       CONTACT_MAIL_TO           = local.contact_mail_to
       CONTACT_MAIL_SUBJECT      = local.contact_mail_subject
       TURNSTILE_SECRET_SSM_NAME = aws_ssm_parameter.turnstile_secret.name
-      ALLOW_ORIGIN              = "https://${local.pages_domain}"
+      # サイトは 2 ホスト名で配信するため、許可オリジンはカンマ区切りのリストで渡す。
+      ALLOW_ORIGINS = join(",", [for d in local.pages_domains : "https://${d}"])
     }
   }
 
@@ -127,7 +128,7 @@ resource "aws_apigatewayv2_api" "contact" {
 
   # 問い合わせフォーム（サイト本体オリジン）からのブラウザアクセスのみ許可する。
   cors_configuration {
-    allow_origins = ["https://${local.pages_domain}"]
+    allow_origins = [for d in local.pages_domains : "https://${d}"]
     allow_methods = ["POST", "OPTIONS"]
     allow_headers = ["content-type"]
     max_age       = 3600

--- a/data.tf
+++ b/data.tf
@@ -6,3 +6,8 @@ data "aws_region" "current" {}
 data "aws_route53_zone" "makedara" {
   zone_id = var.master_makedara_zone_id
 }
+
+# makedara.work（apex）の Route53 ホストゾーン（手動作成済み。Zone ID を tfvars で投入）。
+data "aws_route53_zone" "makedara_apex" {
+  zone_id = var.makedara_zone_id
+}

--- a/lambda/contact/index.mjs
+++ b/lambda/contact/index.mjs
@@ -19,8 +19,11 @@ const SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverif
 const ses = new SESv2Client({ region: process.env.AWS_REGION });
 const ssm = new SSMClient({ region: process.env.AWS_REGION });
 
-// 許可オリジン（CORS レスポンスヘッダ用）。
-const ALLOW_ORIGIN = process.env.ALLOW_ORIGIN;
+// 許可オリジン（CORS レスポンスヘッダ用）。サイトは複数ホスト名で配信するためリストで受け取る。
+const ALLOW_ORIGINS = (process.env.ALLOW_ORIGINS ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
 
 // Turnstile シークレットはモジュールスコープでキャッシュ（コールドスタート後 1 回だけ取得）。
 let secretPromise = null;
@@ -73,20 +76,37 @@ async function verifyTurnstileToken(token, remoteIp) {
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-function corsHeaders() {
+function corsHeaders(allowOrigin) {
   return {
     'content-type': 'application/json',
-    'access-control-allow-origin': ALLOW_ORIGIN,
+    'access-control-allow-origin': allowOrigin,
     'access-control-allow-methods': 'POST,OPTIONS',
     'access-control-allow-headers': 'content-type',
+    // オリジンによって応答ヘッダが変わることを中間キャッシュに伝える。
+    vary: 'Origin',
   };
 }
 
-function response(statusCode, body) {
-  return { statusCode, headers: corsHeaders(), body: JSON.stringify(body) };
+// リクエストの Origin が許可リストにあればエコーバックする。
+// 未知・欠落の場合は先頭の許可オリジンを返し、ブラウザ側で弾かせる。
+// HTTP API（payload format 2.0）はヘッダ名を小文字へ正規化するため origin 固定で参照してよい。
+function resolveAllowOrigin(event) {
+  const origin = event?.headers?.origin;
+  return ALLOW_ORIGINS.includes(origin) ? origin : ALLOW_ORIGINS[0];
+}
+
+// 許可オリジンを束ねたレスポンス生成関数を返す。
+function responder(allowOrigin) {
+  return (statusCode, body) => ({
+    statusCode,
+    headers: corsHeaders(allowOrigin),
+    body: JSON.stringify(body),
+  });
 }
 
 export const handler = async (event) => {
+  const response = responder(resolveAllowOrigin(event));
+
   // CORS プリフライト（HTTP API の CORS 設定が主だが保険として応答）。
   const method = event?.requestContext?.http?.method;
   if (method === 'OPTIONS') {

--- a/locals.tf
+++ b/locals.tf
@@ -11,6 +11,18 @@ locals {
   # Abenotech 事業紹介サイト（master.makedara.work）。
   pages_domain = local.makedara_domain
 
+  # apex ドメイン。master.makedara.work とは別ホストゾーンで管理する。
+  apex_domain = "makedara.work"
+
+  # サイトを配信するホスト名（CloudFront alias / ACM 証明書 / CORS 許可オリジンの対象）。
+  pages_domains = [local.pages_domain, local.apex_domain]
+
+  # ACM DNS 検証レコードの登録先ゾーン（ドメインごとに所属ゾーンが異なる）。
+  pages_cert_zone_ids = {
+    (local.pages_domain) = data.aws_route53_zone.makedara.zone_id
+    (local.apex_domain)  = data.aws_route53_zone.makedara_apex.zone_id
+  }
+
   # 配信バケット名の UUID を一元管理（グローバル一意にするため固定 UUID を付与）。
   pages_bucket_uuid = "fd50acc4-0697-427a-a30f-3a03e12a4bb6"
   pages_bucket_name = "pages-${local.pages_bucket_uuid}"

--- a/route53.tf
+++ b/route53.tf
@@ -24,3 +24,14 @@ resource "aws_route53_record" "dmarc" {
   ttl     = 300
   records = ["v=DMARC1; p=none; rua=mailto:${var.contact_forward_to}"]
 }
+
+# master.makedara.work は apex とは別ホストゾーンで管理しているため、apex ゾーンから NS 委譲する。
+# 従来はお名前ドットコム側の DNS で委譲していたが、apex を Route53 へ移したのに伴いこちらへ移設した。
+# このレコードが無いと master.makedara.work が一切引けなくなる（サイト・メールともに停止）。
+resource "aws_route53_record" "master_delegation" {
+  zone_id = data.aws_route53_zone.makedara_apex.zone_id
+  name    = local.makedara_domain
+  type    = "NS"
+  ttl     = 172800
+  records = data.aws_route53_zone.makedara.name_servers
+}

--- a/static-pages.tf
+++ b/static-pages.tf
@@ -47,25 +47,29 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "pages" {
 resource "aws_acm_certificate" "pages" {
   provider = aws.us_east_1
 
-  domain_name       = local.pages_domain
-  validation_method = "DNS"
+  domain_name               = local.pages_domain
+  subject_alternative_names = [local.apex_domain]
+  validation_method         = "DNS"
 
   lifecycle {
     create_before_destroy = true
   }
 }
 
-# DNS 検証用レコードを Route53 に登録する（証明書は 1 ドメインのため実質 1 レコード）。
+# DNS 検証用レコードを Route53 に登録する。
+# 対象ドメインは master.makedara.work と makedara.work で所属ホストゾーンが異なるため、
+# local.pages_cert_zone_ids でドメインごとの登録先ゾーンを引く。
 resource "aws_route53_record" "pages_cert_validation" {
   for_each = {
     for dvo in aws_acm_certificate.pages.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      type   = dvo.resource_record_type
-      record = dvo.resource_record_value
+      name    = dvo.resource_record_name
+      type    = dvo.resource_record_type
+      record  = dvo.resource_record_value
+      zone_id = local.pages_cert_zone_ids[dvo.domain_name]
     }
   }
 
-  zone_id = data.aws_route53_zone.makedara.zone_id
+  zone_id = each.value.zone_id
   name    = each.value.name
   type    = each.value.type
   ttl     = 300
@@ -96,7 +100,7 @@ resource "aws_cloudfront_distribution" "pages" {
   is_ipv6_enabled     = true
   comment             = local.pages_domain
   default_root_object = "index.html"
-  aliases             = [local.pages_domain]
+  aliases             = local.pages_domains
   price_class         = "PriceClass_200" # 日本を含むエッジロケーション。
 
   origin {
@@ -171,8 +175,9 @@ resource "aws_s3_bucket_policy" "pages" {
   policy = data.aws_iam_policy_document.pages_bucket.json
 }
 
-# --- Route53 ALIAS（master.makedara.work → CloudFront）----------------
+# --- Route53 ALIAS（master.makedara.work / makedara.work → CloudFront）----------------
 # CloudFront の固定ホストゾーン ID は Z2FDTNDATAQYW2（AWS 共通）。
+# 2 ホスト名とも同一 distribution を指し、同じコンテンツを配信する。
 
 resource "aws_route53_record" "pages_a" {
   zone_id = data.aws_route53_zone.makedara.zone_id
@@ -189,6 +194,30 @@ resource "aws_route53_record" "pages_a" {
 resource "aws_route53_record" "pages_aaaa" {
   zone_id = data.aws_route53_zone.makedara.zone_id
   name    = local.pages_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.pages.domain_name
+    zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "pages_apex_a" {
+  zone_id = data.aws_route53_zone.makedara_apex.zone_id
+  name    = local.apex_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.pages.domain_name
+    zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "pages_apex_aaaa" {
+  zone_id = data.aws_route53_zone.makedara_apex.zone_id
+  name    = local.apex_domain
   type    = "AAAA"
 
   alias {

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -29,5 +29,8 @@ sandbox_02_account_email = "sandbox-02@example.com"
 # master.makedara.work の Route53 ホストゾーンID（手動作成後に投入）
 master_makedara_zone_id = "ZXXXXXXXXXXXXX"
 
+# makedara.work（apex）の Route53 ホストゾーンID（手動作成後に投入）
+makedara_zone_id = "ZXXXXXXXXXXXXX"
+
 # 問い合わせメール（contact@master.makedara.work）の転送先
 contact_forward_to = "abechinoid+master@gmail.com"

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,12 @@ variable "master_makedara_zone_id" {
   default     = ""
 }
 
+variable "makedara_zone_id" {
+  description = "makedara.work（apex）の Route53 ホストゾーンID（手動作成後に投入）"
+  type        = string
+  default     = ""
+}
+
 variable "contact_forward_to" {
   description = "問い合わせメールの転送先"
   type        = string


### PR DESCRIPTION
## 概要

新設した `makedara.work`（apex）の Route 53 ホストゾーンを Terraform 管理下に取り込み、apex ゾーンから `master.makedara.work` ゾーンへ NS 委譲する。あわせて Abenotech 事業紹介サイトを `https://makedara.work` と `https://master.makedara.work` の両方（同一 CloudFront distribution・同一コンテンツ）で配信できるようにする。

`master.makedara.work` ゾーンの既存レコード（SPF / DMARC / MX / DKIM / A・AAAA）は一切変更していないため、SES のメール受信・転送・SMTP 送信への影響はない。

## 変更内容

- `variables.tf` / `data.tf`: apex ゾーン参照用に `makedara_zone_id` と `data.aws_route53_zone.makedara_apex` を追加
- `locals.tf`: `apex_domain` / `pages_domains` / `pages_cert_zone_ids`（ドメイン→登録先ゾーンの対応表）を追加
- `route53.tf`: apex ゾーンに `master` の NS 委譲レコードを追加（値は `data...name_servers` から取得し手打ちしない）
- `static-pages.tf`: ACM 証明書に `makedara.work` を SAN 追加／DNS 検証レコードをドメインごとに適切なゾーンへ振り分け／CloudFront `aliases` を 2 ホスト名に／apex の A・AAAA ALIAS を追加
- `contact-api.tf` + `lambda/contact/index.mjs`: API Gateway の `allow_origins` を 2 オリジンに。Lambda は固定値返却をやめ、リクエストの `Origin` を許可リストと突き合わせてエコーバックする方式へ変更（`vary: Origin` も付与）
- `README.md` / `terraform.tfvars.example`: ホストゾーン 2 つ構成・レジストラの委譲先変更・Turnstile 許可ホスト名の追加を反映

## 設計

- 対応 plan: `.claude/plans/issue-53-serve-apex-makedara-work.md`

## 動作確認

実装側で実施済み（`terraform plan` / `apply` はユーザーが実行）:

- `terraform validate` → Success
- 変更した `.tf` 全ファイルの `terraform fmt -check` → 差分なし
- `node --check lambda/contact/index.mjs` → OK

apply 後に確認が必要な項目:

1. `dig NS master.makedara.work +trace` で Route 53 の NS が返ること
2. 非退行: `dig MX/TXT master.makedara.work` が従来どおり、`contact@` 宛メールが Gmail へ転送されること、Gmail からの `contact@` 名義送信ができること
3. `curl -I https://master.makedara.work/` と `curl -I https://makedara.work/` がともに 200、証明書の SAN に両ドメインが含まれること
4. 両ホスト名の問い合わせフォームから送信 → 成功し通知メールが届くこと

## 注意事項

- **apply 前に `terraform.tfvars` へ `makedara_zone_id` の設定が必要。**
- **Cloudflare Turnstile の許可ホスト名に `makedara.work` の追加が必要**（未追加だと apex 経由の送信が失敗する）。
- ACM は SAN 追加により証明書が置換される。`create_before_destroy = true` のため無停止だが、apex の NS 委譲がレジストラ側で完了していないと DNS 検証が通らず apply が待機し続ける。
- 重複コンテンツ対策（`<link rel="canonical">`）は本 PR のスコープ外。

Close #53