### PR TITLE
makedara.work apex ゾーンにサブドメインのNS委譲を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ NS 委任・SES サンドボックス解除・Gmail 設定は Terraform 管理�
    - お名前ドットコムのネームサーバー設定を、`makedara.work` ゾーンの NS 4 本に変更する
    - `master.makedara.work` への委任は Terraform が `makedara.work` ゾーン内に NS レコード
      （`aws_route53_record.master_delegation`）として作成するため、レジストラ側の設定は不要
+   - `kidsword` / `kidsword-stg` / `multibook-stg` / `static` / `static-stg` の各サブドメインも
+     同ゾーンから委任する（`aws_route53_record.subdomain_delegation`）。委任先ホストゾーンは
+     各メンバーアカウント側にあり data 参照できないため、NS 値は `locals.tf` の
+     `subdomain_delegations` に直接記述している。委任先ゾーンを作り直した場合はこの値の更新が必要
 
 3. **terraform apply（ユーザーが実行）**
    ```bash

--- a/locals.tf
+++ b/locals.tf
@@ -29,4 +29,42 @@ locals {
 
   # 問い合わせ通知メールの件名。
   contact_mail_subject = "【Abenotech】お問い合わせ"
+
+  # apex ゾーンから NS 委譲するサブドメイン群（キーはラベルのみ）。
+  # 委譲先ホストゾーンは各メンバーアカウント（organizations.tf 参照）側にあり、
+  # master アカウントの credential では data.aws_route53_zone で参照できないため NS 値を直接記述する。
+  # 委譲先ゾーンを作り直すと NS が変わり委譲が切れるので、その際はここの値も追従させること。
+  # master.makedara.work は aws_route53_record.master_delegation で別管理。
+  subdomain_delegations = {
+    "kidsword" = [
+      "ns-74.awsdns-09.com.",
+      "ns-973.awsdns-57.net.",
+      "ns-1087.awsdns-07.org.",
+      "ns-1579.awsdns-05.co.uk.",
+    ]
+    "kidsword-stg" = [
+      "ns-374.awsdns-46.com.",
+      "ns-582.awsdns-08.net.",
+      "ns-1235.awsdns-26.org.",
+      "ns-1636.awsdns-12.co.uk.",
+    ]
+    "multibook-stg" = [
+      "ns-400.awsdns-50.com.",
+      "ns-762.awsdns-31.net.",
+      "ns-1517.awsdns-61.org.",
+      "ns-1616.awsdns-10.co.uk.",
+    ]
+    "static" = [
+      "ns-209.awsdns-26.com.",
+      "ns-995.awsdns-60.net.",
+      "ns-1243.awsdns-27.org.",
+      "ns-1894.awsdns-44.co.uk.",
+    ]
+    "static-stg" = [
+      "ns-95.awsdns-11.com.",
+      "ns-647.awsdns-16.net.",
+      "ns-1113.awsdns-11.org.",
+      "ns-1810.awsdns-34.co.uk.",
+    ]
+  }
 }

--- a/route53.tf
+++ b/route53.tf
@@ -35,3 +35,16 @@ resource "aws_route53_record" "master_delegation" {
   ttl     = 172800
   records = data.aws_route53_zone.makedara.name_servers
 }
+
+# 各メンバーアカウントが持つサブドメインのホストゾーンへ apex ゾーンから NS 委譲する。
+# master_delegation と同様、従来はお名前ドットコム側の DNS で委譲していたものの移設。
+# このレコードが無いと該当サブドメインが一切引けなくなる。
+resource "aws_route53_record" "subdomain_delegation" {
+  for_each = local.subdomain_delegations
+
+  zone_id = data.aws_route53_zone.makedara_apex.zone_id
+  name    = "${each.key}.${local.apex_domain}"
+  type    = "NS"
+  ttl     = 172800
+  records = each.value
+}


### PR DESCRIPTION
## 概要

`makedara.work`（apex）の Route 53 ホストゾーンに、5 つのサブドメイン（`kidsword` / `kidsword-stg` / `multibook-stg` / `static` / `static-stg`）の NS 委譲レコードを追加します。

apex の DNS 管理を Route 53 へ移設した際（#54）、`master.makedara.work` の委譲だけが移設済みで、他のサブドメインが未移設のまま残っていました。apex ゾーンに NS レコードが無い限りこれらは名前解決できません。

## 変更内容

- `locals.tf`: `subdomain_delegations` マップを追加し、5 サブドメインの NS 値を一元管理
- `route53.tf`: `aws_route53_record.subdomain_delegation` を追加（`for_each` でマップを展開）。TTL は委譲 NS の標準値 172800 とし、既存の `master_delegation` と揃えた
- `README.md`: NS 委任手順にサブドメイン委譲の説明を追記

### 補足

委譲先ホストゾーンは各メンバーアカウント側にあり、このリポジトリの provider では `data.aws_route53_zone` で参照できません。そのため `master_delegation` のような動的取得ではなく NS 値をハードコードしています。委譲先ゾーンを作り直すと委譲が切れる点を `locals.tf` のコメントと README に明記しました。

`master.makedara.work` は既存の `aws_route53_record.master_delegation` が同じ委譲を管理しているため、本 PR では追加していません。

## 設計

- 対応 plan: `.claude/plans/issue-55-add-subdomain-ns-delegation.md`

## 動作確認

- [x] `terraform fmt -check` パス
- [x] `terraform validate` パス（Success! The configuration is valid.）
- [ ] `terraform plan` で **追加 5 件のみ・変更/削除 0 件**であること（`master_delegation` に差分が出ないこと）を確認 ※ユーザー実行
- [ ] apply 後に各サブドメインの委譲を確認 ※ユーザー実行
  ```bash
  for d in kidsword kidsword-stg multibook-stg static static-stg; do
    echo "=== $d ==="; dig +short NS "$d.makedara.work" @8.8.8.8
  done
  ```

Close #55