### PR TITLE
fix: S3 SSE 設定の恒常的 diff（blocked_encryption_types）を解消

### DIFF
--- a/ses-inbound.tf
+++ b/ses-inbound.tf
@@ -36,6 +36,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "ses_inbound" {
   bucket = aws_s3_bucket.ses_inbound.id
 
   rule {
+    # AWS は 2026-03 以降 新規バケットの SSE-C アップロードを自動ブロックする。
+    # 実態に合わせて明示しないと毎回 plan に差分が出るため固定する。
+    blocked_encryption_types = ["SSE-C"]
+
     apply_server_side_encryption_by_default {
       # SSE-S3（AES256）。SSE-KMS にすると SES 側に KMS 権限が別途必要になるため使わない。
       sse_algorithm = "AES256"

--- a/static-pages.tf
+++ b/static-pages.tf
@@ -35,6 +35,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "pages" {
   bucket = aws_s3_bucket.pages.id
 
   rule {
+    # AWS は 2026-03 以降 新規バケットの SSE-C アップロードを自動ブロックする。
+    # 実態に合わせて明示しないと毎回 plan に差分が出るため固定する。
+    blocked_encryption_types = ["SSE-C"]
+
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }


### PR DESCRIPTION
## 概要

`aws_s3_bucket_server_side_encryption_configuration` の 2 リソース（`pages` / `ses_inbound`）で、`terraform apply` を何度実行しても `rule` ブロックの差分が消えない状態になっていた。
AWS provider 6.26.0 で追加された `blocked_encryption_types` を `.tf` に記述していなかったことによる drift のため、AWS 側の実態（`["SSE-C"]`）に合わせて明示する。

## 変更内容

- `static-pages.tf` の `aws_s3_bucket_server_side_encryption_configuration.pages` の `rule` に `blocked_encryption_types = ["SSE-C"]` を追加
- `ses-inbound.tf` の `aws_s3_bucket_server_side_encryption_configuration.ses_inbound` に同様の追加
- いずれも理由をコメントで明記

## 設計

- 対応 plan: `.claude/plans/issue-57-fix-s3-sse-perpetual-diff.md`

## 動作確認

- `terraform fmt -check -diff` … 差分なし（OK）
- `terraform validate` … Success
- `terraform plan` … **未実施**。マージ前にレビュアー（実行者）側で実行し、`No changes.` になることを確認してください。

Close #57