### PR TITLE
master.makedara.work から makedara.work へ 301 リダイレクトして重複コンテンツを解消する

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,19 +138,47 @@ NS 委任・SES サンドボックス解除・Gmail 設定は Terraform 管理�
    - `contact@master.makedara.work` にテスト送信 → Gmail に転送されること
    - Gmail から返信 → 元送信者に `contact@` 名義で届くことを確認
 
-### 重要: Abenotech 事業紹介サイト（makedara.work / master.makedara.work）について
+### 重要: Abenotech 事業紹介サイト（makedara.work、旧 master.makedara.work）について
 
-`https://makedara.work/` と `https://master.makedara.work/` の両方（同一 CloudFront
-distribution・同一コンテンツ）で事業紹介サイト（静的 3 ページ）を配信し、問い合わせ
-フォームは Cloudflare Turnstile で Bot を弾いたうえで SES メール通知します。配信は
+`https://makedara.work/`（apex）を正規 URL として事業紹介サイト（静的 3 ページ）を配信し、
+問い合わせフォームは Cloudflare Turnstile で Bot を弾いたうえで SES メール通知します。配信は
 CloudFront + S3（OAC）、問い合わせ API は API Gateway + Lambda 構成です。
 静的コンテンツ（`web/` 配下）は Terraform では管理せず、`scripts/deploy-pages.sh` で配置します。
 Turnstile ウィジェットの作成・シークレット投入・HTML への値埋め込みは手動で実施します。
 
+`https://master.makedara.work/` および CloudFront デフォルトドメイン
+（`*.cloudfront.net`）は同一 distribution 上に残っていますが、viewer-request の
+CloudFront Function（`aws_cloudfront_function.redirect_to_apex`、コード本体は
+`cloudfront-functions/redirect-to-apex.js.tftpl`）が apex 以外の Host を検知し
+`https://makedara.work` へ 301 リダイレクトします（パス・クエリ文字列は維持）。
+`master.makedara.work` の ACM SAN・Route53 ALIAS レコードは TLS ハンドシェイクに必要なため
+削除せず残しています。各ページの `<head>` にも自己参照 `rel="canonical"` を入れて正規化しています。
+
 クローラー向けに `web/robots.txt` と `web/sitemap.xml` も同じく `web/` 配下で管理します。
-サイトは 2 ホスト名で配信しますが、Google Search Console に登録済みの apex
-（`https://makedara.work/`）を正規 URL として記載しています。ページを追加・削除した場合は
-`web/sitemap.xml` の `<url>` と `<lastmod>` を更新してください。
+Google Search Console に登録済みの apex（`https://makedara.work/`）を正規 URL として
+記載しています。ページを追加・削除した場合は `web/sitemap.xml` の `<url>` と `<lastmod>`
+を更新してください。
+
+#### CloudFront Function の apply 前セルフテスト
+
+**viewer-request 関数が実行時エラーを起こすと CloudFront は 5xx を返し全ページが
+閲覧不能になるため、`terraform apply` 前に必ず `test-function` で単体テストすること。**
+
+```bash
+export AWS_PROFILE=master
+ETAG=$(aws cloudfront describe-function --name pages-redirect-to-apex \
+  --query 'ETag' --output text)
+aws cloudfront test-function --name pages-redirect-to-apex \
+  --if-match "$ETAG" --stage LIVE --event-object fileb://event.json
+```
+
+`event.json` に以下 3 パターンを用意して確認する。
+
+| ケース | `headers.host.value` | 期待結果 |
+| --- | --- | --- |
+| apex | `makedara.work` | `request` がそのまま返る（`statusCode` なし） |
+| master + クエリ | `master.makedara.work`（`uri: /contact.html`, `querystring` に utm 2 件） | 301 / `Location: https://makedara.work/contact.html?utm_source=...&utm_medium=...` |
+| CloudFront ドメイン | `dxxxxxxxx.cloudfront.net` | 301 / `Location: https://makedara.work/` |
 
 #### 実行手順
 
@@ -194,10 +222,12 @@ Turnstile ウィジェットの作成・シークレット投入・HTML への�
    - `web/` を配信バケットへ同期し、CloudFront キャッシュを無効化します
 
 6. **疎通確認**
-   - `https://master.makedara.work/` と `https://makedara.work/` の両方が HTTPS で表示され、
-     3 ページを相互遷移できること
-   - 両ホスト名の問い合わせフォームで Turnstile を通過し送信 → `contact@master.makedara.work`
+   - `https://makedara.work/` が HTTPS で表示され、3 ページを相互遷移できること
+   - `https://master.makedara.work/` へアクセスすると `https://makedara.work/` へ 301
+     リダイレクトされること（`curl -sI https://master.makedara.work/ | grep -iE '^(HTTP|location)'`）
+   - apex 上の問い合わせフォームで Turnstile を通過し送信 → `contact@master.makedara.work`
      に通知が届き、既存の転送で運営 Gmail に届くこと。その返信が送信者に届くこと（Reply-To）
+   - ページソースに `rel="canonical"` が出ていること
 
 > 補足: 問い合わせ通知の宛先は検証済みの `contact@master.makedara.work` のため、
 > SES サンドボックスのままでも通知メールは送信されます（既存の受信転送に相乗り）。

--- a/cloudfront-functions/redirect-to-apex.js.tftpl
+++ b/cloudfront-functions/redirect-to-apex.js.tftpl
@@ -1,0 +1,37 @@
+// 正規ホスト名（apex）以外へのアクセスを https://${apex_domain} へ 301 リダイレクトする。
+// master.makedara.work と CloudFront デフォルトドメイン（dxxxx.cloudfront.net）が対象。
+// キャッシュキーに Host を含めていないため、キャッシュ参照前に走る viewer-request で判定する。
+function handler(event) {
+    var request = event.request;
+    var host = request.headers.host ? request.headers.host.value : '';
+
+    if (host === '${apex_domain}') {
+        return request;
+    }
+
+    // querystring はオブジェクトで渡るため、リダイレクト先 URL 用に組み直す。
+    // 同名キーが複数ある場合 value は multiValue の 1 件目と重複するので、
+    // multiValue があるときはそちらだけを使う。
+    var params = [];
+    for (var name in request.querystring) {
+        var q = request.querystring[name];
+        var values = q.multiValue || [q];
+        for (var i = 0; i < values.length; i++) {
+            params.push(encodeURIComponent(name) + '=' + encodeURIComponent(values[i].value));
+        }
+    }
+
+    var location = 'https://${apex_domain}' + request.uri +
+        (params.length > 0 ? '?' + params.join('&') : '');
+
+    return {
+        statusCode: 301,
+        statusDescription: 'Moved Permanently',
+        headers: {
+            'location': { value: location },
+            // 恒久リダイレクトはブラウザに無期限キャッシュされうる。
+            // 撤回可能にするため TTL を 1 時間に制限する。
+            'cache-control': { value: 'max-age=3600' }
+        }
+    };
+}

--- a/static-pages.tf
+++ b/static-pages.tf
@@ -89,6 +89,19 @@ resource "aws_acm_certificate_validation" "pages" {
   validation_record_fqdns = [for r in aws_route53_record.pages_cert_validation : r.fqdn]
 }
 
+# --- CloudFront Function（非正規ホスト名を apex へ 301）----------------------
+
+resource "aws_cloudfront_function" "redirect_to_apex" {
+  name    = "pages-redirect-to-apex"
+  runtime = "cloudfront-js-2.0"
+  comment = "Redirect non-apex hosts to https://${local.apex_domain} (301)"
+  publish = true
+
+  code = templatefile("${path.module}/cloudfront-functions/redirect-to-apex.js.tftpl", {
+    apex_domain = local.apex_domain
+  })
+}
+
 # --- CloudFront（OAC 経由で S3 を配信）-------------------------------------
 
 resource "aws_cloudfront_origin_access_control" "pages" {
@@ -121,6 +134,11 @@ resource "aws_cloudfront_distribution" "pages" {
 
     # AWS マネージドキャッシュポリシー「CachingOptimized」。
     cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.redirect_to_apex.arn
+    }
   }
 
   # 直リンク（存在しないパス）でも Home を返す簡易フォールバック。

--- a/web/contact.html
+++ b/web/contact.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>お問い合わせ — Abenotech（アベノテック）</title>
 <meta name="description" content="アベノテックへのお問い合わせフォーム。">
+<link rel="canonical" href="https://makedara.work/contact.html">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Abenotech（アベノテック）— モバイルとクラウドで、アイデアを、動かす。</title>
 <meta name="description" content="アベノテックは、スマートフォンアプリの企画・開発から、AWSインフラの構築、Web開発までを一貫して支援する個人事業です。">
+<link rel="canonical" href="https://makedara.work/">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>プライバシーポリシー — Abenotech（アベノテック）</title>
 <meta name="description" content="アベノテックの個人情報の取り扱い方針（プライバシーポリシー）。">
+<link rel="canonical" href="https://makedara.work/privacy.html">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">


### PR DESCRIPTION
## 概要

Abenotech 事業紹介サイトは、同一 CloudFront distribution で `https://makedara.work/`（apex）と `https://master.makedara.work/` の 2 ホスト名からまったく同じコンテンツを配信しており、検索エンジンから見て重複コンテンツとなっていた。viewer-request の CloudFront Function で apex 以外のホスト名を `https://makedara.work` へ 301 リダイレクトし、各 HTML に自己参照 `rel="canonical"` を追加して正規化する。

## 変更内容

- `cloudfront-functions/redirect-to-apex.js.tftpl` を新規作成（apex 以外の Host を 301 リダイレクトする CloudFront Function 本体、パス・クエリ文字列は維持）
- `static-pages.tf` に `aws_cloudfront_function.redirect_to_apex` を追加し、`default_cache_behavior` の `function_association`（viewer-request）で関連付け
- `web/index.html` / `web/contact.html` / `web/privacy.html` に自己参照 `rel="canonical"` を追加
- `README.md` にリダイレクト仕様・apply 前の `test-function` によるセルフテスト手順・疎通確認手順を追記

`master.makedara.work` の ACM SAN・Route53 ALIAS レコードは TLS ハンドシェイクに必要なため削除していない。

## 設計

- 対応 plan: `.claude/plans/issue-59-redirect-master-to-apex.md`

## 動作確認

- `terraform fmt -check` … 差分なし
- `terraform validate` … 成功
- **要ユーザー作業**: apply 前に CloudFront Function の `test-function`（apex / master+クエリ / CloudFront デフォルトドメインの 3 パターン）による単体テストを実施してください。viewer-request 関数の実行時エラーは全ページ 5xx に直結するため必須です（README 参照）
- **要ユーザー作業**: マージ後、`terraform apply` → `./scripts/deploy-pages.sh` → README 記載の疎通確認（301 リダイレクト・apex 200・canonical タグ表示）を実施してください

Close #59